### PR TITLE
Give flask a startupProbe; its liveness probe made booting impossible

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -140,6 +140,12 @@ jobs:
           host: ${{ env.SERVER_HOST }}
           username: ${{ env.SSH_USERNAME }}
           key: ${{ env.SSH_PRIVATE_KEY }}
+          # The action's default command_timeout is 10m, but flask's startupProbe
+          # allows up to 15 minutes for its boot-time data fetch and the deploy script
+          # blocks on `kubectl rollout status`. Without this the SSH step is killed
+          # mid-rollout and the deploy reports failure for a pod that was starting
+          # normally.
+          command_timeout: 25m
           script: |
             set -e # Stop execution on any error
 

--- a/kubernetes/deployment/flask-deployment.yml
+++ b/kubernetes/deployment/flask-deployment.yml
@@ -6,6 +6,11 @@ metadata:
   name: flask
   namespace: aqra
 spec:
+  # Must exceed the startupProbe budget below (90 x 10s = 15 min), or the Deployment
+  # reports ProgressDeadlineExceeded -- and `kubectl rollout status` fails the deploy --
+  # while the pod is still legitimately starting. The default is 600s, which is shorter
+  # than this container's own worst-case boot.
+  progressDeadlineSeconds: 1200
   replicas: 1
   selector:
     matchLabels:
@@ -32,22 +37,45 @@ spec:
           # /api/v1/* returned 503. Same bug, same fix, as aqra-frontend PR #10.
           image: ghcr.io/trencho/air-quality-rest-api:latest
           imagePullPolicy: Always
-          livenessProbe:
-            failureThreshold: 1
+          # This container cannot serve anything until a bulk data fetch finishes.
+          # create_app() calls init_data() BEFORE returning (src/api/config/__init__.py),
+          # and gunicorn imports the factory, so the worker does not bind a port until
+          # that pulse.eco fetch completes. On a cold volume that is minutes.
+          #
+          # The old settings could not survive that. Liveness had failureThreshold: 1
+          # with initialDelaySeconds: 60 and timeoutSeconds: 60, so a container that
+          # was not answering by ~t+120s was killed and restarted straight back into
+          # the same race -- an unwinnable crash loop, whatever the image. It is the
+          # same failureThreshold: 1 pattern that drove mongo's ~1,050 restarts.
+          #
+          # A startupProbe is the mechanism built for exactly this: while it is
+          # running, liveness and readiness are disabled entirely, so a slow boot can
+          # never be mistaken for a hung process. 90 x 10s = 15 minutes of grace.
+          startupProbe:
+            failureThreshold: 90
             httpGet:
               path: /api/v1/healthz/live
               port: 80
-            initialDelaySeconds: 60
-            periodSeconds: 300
-            timeoutSeconds: 60
+            periodSeconds: 10
+          # Takes over only once startupProbe has succeeded, so no initialDelaySeconds
+          # is needed here -- boot time is the startup probe's job, not liveness's.
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /api/v1/healthz/live
+              port: 80
+            periodSeconds: 30
+            timeoutSeconds: 10
+          # periodSeconds was 300: a readiness check that missed its first attempt did
+          # not retry for five minutes, so a perfectly healthy pod stayed out of
+          # service -- and the Service kept returning 503 -- for most of that.
           readinessProbe:
-            failureThreshold: 2
+            failureThreshold: 3
             httpGet:
               path: /api/v1/healthz/ready
               port: 80
-            initialDelaySeconds: 60
-            periodSeconds: 300
-            timeoutSeconds: 60
+            periodSeconds: 15
+            timeoutSeconds: 10
           name: flask
           ports:
             - containerPort: 80


### PR DESCRIPTION
The image is pullable now (#18 landed, GHCR package is public and returns 200 to an anonymous token), but flask still never becomes ready and `/api/v1/cities/` still returns 503. **The probes are why, and they could not have worked with any image.**

## The unwinnable loop

`create_app()` calls `init_data()` **before returning** (`src/api/config/__init__.py:41`), and gunicorn imports the factory — so the worker does not bind a port until a full pulse.eco fetch completes. On a cold volume that takes minutes.

Against that, liveness was:

```yaml
initialDelaySeconds: 60
timeoutSeconds: 60
failureThreshold: 1     # one failure kills the container
```

A container not answering by ~t+120s was killed and restarted straight back into the same race. It is the same `failureThreshold: 1` pattern that drove mongo's ~1,050 restarts — which this repo had already been bitten by once, and which #18 fixed on mongo while deliberately leaving flask alone. That call was wrong.

Readiness was no better: `periodSeconds: 300` meant a check that missed its first attempt did not retry for **five minutes**, so a healthy pod stayed out of service — and the Service kept returning 503 — for most of that window.

## The fix

A `startupProbe` is the mechanism built for this. While it runs, liveness and readiness are disabled entirely, so a slow boot can never be mistaken for a hung process.

| Probe | Setting | Budget |
|---|---|---|
| `startupProbe` | `failureThreshold: 90`, `periodSeconds: 10` | 15 minutes of boot grace |
| `livenessProbe` | `failureThreshold: 3`, `periodSeconds: 30`, `timeoutSeconds: 10` | takes over after startup succeeds |
| `readinessProbe` | `failureThreshold: 3`, `periodSeconds: 15`, `timeoutSeconds: 10` | converges in seconds, not minutes |

Two supporting limits had to move with it, or the deploy would report failure for a pod that was starting normally:

- **`progressDeadlineSeconds: 1200`** on the Deployment. The default 600s is shorter than this container's own worst-case boot, so `kubectl rollout status` would fail mid-start. (This is also why the previous deploy reported `exceeded its progress deadline` 0.3s after applying — it was reading a stale condition left from months of `ErrImageNeverPull`.)
- **`command_timeout: 25m`** on the SSH action. Its default is 10m and the deploy script blocks on `kubectl rollout status`.

The three are deliberately ordered: 900s startup < 1200s progress deadline < 25m SSH timeout.

## Worth doing properly later

`init_data()` should not run inside `create_app()` at all. A boot that blocks on a bulk network fetch is the reason a 15-minute startup budget is needed in the first place, and the scheduler already owns periodic fetching. That is a code change, not a manifest one, so it is not in this PR.

## Verification

`kubectl kustomize kubernetes/` renders; both changed YAML files parse; the three timeouts are consistent with each other. The real check is after merge: the deploy completes and `curl https://aqra.feit.ukim.edu.mk/api/v1/cities/` returns **200 instead of 503**.