### PR TITLE
Stop reading stale rollout status, and dump diagnostics when a rollout fails

### DIFF
--- a/.github/workflows/deploy_kubernetes_resources.sh
+++ b/.github/workflows/deploy_kubernetes_resources.sh
@@ -16,17 +16,56 @@ if ! kubectl cluster-info --request-timeout=15s >/dev/null 2>&1; then
 fi
 echo "Kubernetes API server reachable - proceeding with the deploy."
 
+# Apply a Deployment and wait for it, without tripping over stale status.
+#
+# `kubectl rollout status` reads .status.conditions, which still describe the PREVIOUS
+# rollout until the deployment controller has observed this apply. Run back-to-back with
+# `kubectl apply`, it therefore reports the OLD result: flask's deploy failed twice with
+# "exceeded its progress deadline" emitted ~100ms after the apply, long before the new
+# pod had done anything at all. Raising progressDeadlineSeconds does not help, because
+# the stale condition is not recomputed until a new rollout is under way.
+#
+# So: wait for .status.observedGeneration to catch up to .metadata.generation first.
+# Only then does rollout status describe THIS rollout.
+deploy_and_wait() {
+  local name=$1
+  local timeout=${2:-10m}
+
+  echo "Deploying ${name}..."
+  kubectl apply -f "${KUBERNETES_DIR}/deployment/${name}-deployment.yml"
+
+  local generation observed
+  generation=$(kubectl get "deployment/${name}" -n aqra -o jsonpath='{.metadata.generation}')
+  for _ in $(seq 1 60); do
+    observed=$(kubectl get "deployment/${name}" -n aqra -o jsonpath='{.status.observedGeneration}')
+    if [ "${observed:-0}" -ge "${generation:-1}" ]; then
+      break
+    fi
+    sleep 1
+  done
+
+  if ! kubectl rollout status "deployment/${name}" -n aqra --watch=true --timeout="${timeout}"; then
+    echo "=============================================================="
+    echo "ERROR: ${name} did not become ready. Diagnostics follow."
+    echo "=============================================================="
+    echo "--- pods ---"
+    kubectl get pods -n aqra -l "io.kompose.service=${name}" -o wide || true
+    echo "--- describe (events are the useful part) ---"
+    kubectl describe pod -n aqra -l "io.kompose.service=${name}" | tail -40 || true
+    echo "--- current container logs ---"
+    kubectl logs -n aqra -l "io.kompose.service=${name}" --tail=60 --all-containers || true
+    echo "--- previous container logs (populated if it crash-looped) ---"
+    kubectl logs -n aqra -l "io.kompose.service=${name}" --tail=60 --all-containers --previous || true
+    return 1
+  fi
+}
+
 echo "Applying base resources..."
 kubectl apply -k ${KUBERNETES_DIR}
 
-echo "Deploying MongoDB first to avoid dependency issues..."
-kubectl apply -f "${KUBERNETES_DIR}/deployment/mongo-deployment.yml"
-kubectl rollout status deployment/mongo -n aqra --watch=true
-
-echo "Deploying Redis..."
-kubectl apply -f "${KUBERNETES_DIR}/deployment/redis-deployment.yml"
-kubectl rollout status deployment/redis -n aqra --watch=true
-
-echo "Deploying Flask API..."
-kubectl apply -f "${KUBERNETES_DIR}/deployment/flask-deployment.yml"
-kubectl rollout status deployment/flask -n aqra --watch=true
+# MongoDB first to avoid dependency issues.
+deploy_and_wait mongo 10m
+deploy_and_wait redis 10m
+# Longer: flask's create_app() blocks on a bulk data fetch before the worker binds, and
+# its startupProbe allows 15 minutes for that.
+deploy_and_wait flask 20m


### PR DESCRIPTION
flask's deploy has now failed twice with `exceeded its progress deadline` emitted **~100ms after the apply**:

```
15:07:05.2103912  deployment.apps/flask configured
15:07:05.3220554  error: deployment "flask" exceeded its progress deadline
```

That is not a verdict on the new pod. Nothing had happened yet.

## The race

`kubectl rollout status` reads `.status.conditions`, which still describe the **previous** rollout until the deployment controller has observed the new apply. Run back-to-back with `kubectl apply`, it reports the old result.

flask had been failing to pull for months, so its stale condition was `ProgressDeadlineExceeded` — and every deploy inherited that verdict instantly, then aborted under `set -e` before the pod had a chance to do anything.

Raising `progressDeadlineSeconds` to 1200 in #19 did not help, because the stale condition is not recomputed until a new rollout is actually under way.

## The fix

`deploy_and_wait` now waits for `.status.observedGeneration` to catch up to `.metadata.generation` before checking rollout status, so the status describes *this* rollout rather than the last one. Explicit per-deployment timeouts too: **20m for flask** (its startupProbe allows 15 minutes for the boot-time data fetch), 10m for the others.

## Diagnostics on failure

When a rollout does fail, the script now dumps:

- `kubectl get pods -o wide`
- `kubectl describe pod | tail -40` — the events are the useful part
- current container logs
- **previous** container logs, which are populated only if it crash-looped

Both failures so far were diagnosed from timestamps and inference, because CI had no visibility into the cluster. That was avoidable. The next failure should arrive with evidence attached rather than requiring a guess — including the answer to the question still open: whether flask is crash-looping, still backing off on the pull, or simply slow to boot.

## Verification

`bash -n` passes; the three `<name>-deployment.yml` files the helper derives all exist. The real check is the next deploy: either flask rolls out and `curl https://aqra.feit.ukim.edu.mk/api/v1/cities/` returns 200, or it fails with a diagnostic dump that finally says why.