### PR TITLE
Rebuild NumPy with cpu-baseline=none; the node's CPU cannot run the stock wheel

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,45 @@
+# ⚠️ TEMPORARY — remove this stage once the deploy node's CPU is fixed. See below.
+#
+# NumPy's published manylinux wheels are compiled with an x86-64-v2 baseline
+# (SSE3/SSSE3/SSE4.1/SSE4.2/POPCNT). The deploy node does not have those
+# instructions, so importing NumPy aborts the process outright:
+#
+#     Error: NumPy was built with baseline optimizations:
+#     (X86_V2) but your machine doesn't support: (X86_V2).
+#
+# gunicorn imported the app, NumPy died, the container exited, and the pod
+# crash-looped 81 times in 19 minutes. It is the same root cause as MongoDB
+# being stuck on 4.4 here: the node also has no AVX. Both point at a VM using a
+# generic CPU model (e.g. QEMU's default) that masks features the physical host
+# probably has.
+#
+# Rebuilding NumPy with `cpu-baseline=none` produces a build that runs on any
+# x86 CPU, selecting optimised code paths at runtime instead of requiring them
+# at load time. Chosen over downgrading NumPy below 2.0, which has no cp314
+# wheels and would have dragged Python off 3.14 and cascaded into pandas,
+# scipy and scikit-learn.
+#
+# TO REVERT once the hypervisor exposes a modern CPU model: delete this stage
+# and the "Reinstall NumPy" step in the runtime image. Nothing else changed --
+# no version was downgraded, so there is nothing to restore.
+FROM python:3.14.6-slim AS numpy-builder
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends build-essential && \
+    rm -rf /var/lib/apt/lists/*
+
+# The version is read from requirements rather than repeated here, so a
+# Dependabot bump cannot silently leave this stage building a stale NumPy.
+RUN --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=bind,source=requirements,target=requirements \
+    NUMPY_VERSION="$(grep -iE '^numpy==' requirements/common.txt | cut -d= -f3)" && \
+    if [ -z "${NUMPY_VERSION}" ]; then echo "ERROR: no numpy== pin found in requirements/common.txt" >&2; exit 1; fi && \
+    echo "Building NumPy ${NUMPY_VERSION} with cpu-baseline=none" && \
+    pip wheel --no-cache-dir --no-deps --no-binary=numpy -w /wheels \
+        --config-settings=setup-args="-Dcpu-baseline=none" \
+        "numpy==${NUMPY_VERSION}"
+
+
 FROM python:3.14.6-slim
 
 LABEL maintainer="Aleksandar Trenchevski <atrenchevski@gmail.com>"
@@ -27,6 +69,19 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=requirements,target=requirements \
     pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r requirements/prod.txt
+
+# ⚠️ TEMPORARY, paired with the numpy-builder stage above — see the comment there.
+# Replaces the x86-64-v2 wheel pip just installed with the baseline-free build.
+# Same version, so this is a swap of machine code, not a downgrade.
+COPY --from=numpy-builder /wheels /tmp/wheels
+#
+# The check fails the BUILD if the rebuilt NumPy still demands SSE4/AVX, rather
+# than letting the node discover it by crash-looping. Introspection is
+# best-effort: the config key names are not a stable API, so a missing key reads
+# as an empty baseline and passes, and the build log remains the final word.
+RUN pip install --no-cache-dir --force-reinstall --no-deps /tmp/wheels/numpy-*.whl && \
+    rm -rf /tmp/wheels && \
+    python -c "import numpy, sys; b = [str(f).upper() for f in numpy.__config__.show(mode='dicts').get('SIMD Extensions', {}).get('baseline', [])]; print('NumPy', numpy.__version__, '| baseline:', b or '(none - runs on any x86_64)'); bad = [f for f in b if f.startswith(('SSE3', 'SSSE3', 'SSE4', 'AVX', 'X86_V'))]; sys.exit('ERROR: NumPy baseline still requires %s - cpu-baseline=none did not apply' % bad) if bad else None"
 
 # Copy the source code into the container.
 COPY . .


### PR DESCRIPTION
The diagnostics from #20 found the real reason flask has never served — and it is none of the things the last three PRs fixed.

```
Running app in production mode!
INFO:__config__:Gunicorn configured successfully
Error: NumPy was built with baseline optimizations:
(X86_V2) but your machine doesn't support: (X86_V2).

Warning  BackOff  4m54s (x81 over 19m)  Back-off restarting failed container flask
```

NumPy's published manylinux wheels are compiled with an **x86-64-v2** baseline (SSE3/SSSE3/SSE4.1/SSE4.2/POPCNT). The deploy node lacks those instructions, so gunicorn imports the app, NumPy aborts at load, and the container exits. **81 restarts in 19 minutes.**

The image pull itself is fine — the same events show `Successfully pulled image ... in 3.543s`, so #18 worked. #19's probes and #20's rollout-status fix were also both real bugs. But none of them could ever have made the API work, because the application cannot execute on this CPU.

## Why the CPU

This is the same root cause as MongoDB being pinned to `4.4` in this repo: the node also has **no AVX**. A machine missing both AVX and x86-64-v2 is either pre-2008 hardware or — far more likely — a VM using a generic CPU model (QEMU's default `qemu64` lacks SSE4.2) that masks features the physical host almost certainly has.

The owner cannot reach the hypervisor config and is raising it with support. **This PR is the interim fix.**

## The fix

Rebuild NumPy from source with [`cpu-baseline=none`](https://numpy.org/doc/stable/reference/simd/build-options.html), which NumPy documents as producing a build compatible with all x86 CPUs, relying on runtime-dispatched code paths instead of load-time requirements.

- Done in a **separate builder stage**, so the runtime image carries no compiler toolchain.
- The version is **read from `requirements/common.txt`**, so a Dependabot bump cannot silently leave the stage building a stale NumPy.
- A build-time assertion fails the build if the resulting baseline still demands SSE4/AVX, rather than letting the node discover it by crash-looping. It degrades safely: NumPy's config keys are not a stable API, so a missing key reads as an empty baseline and passes.

## Explicitly not a downgrade

Pinning `numpy<2` would mean no `cp314` wheels, dragging Python off 3.14 (pinned in four places) and cascading into pandas, scipy and scikit-learn.

**Nothing here is downgraded.** So when the CPU is fixed, the revert is simply: delete the `numpy-builder` stage and the reinstall step. There are no versions to restore — which is the whole reason for taking this route over a downgrade.

## What is still unverified

Only NumPy is *known* to demand x86-64-v2. `scipy`, `pandas`, `scikit-learn`, `xgboost` and `lightgbm` are all compiled too, and if any of them shares the requirement it will surface as the next crash. The difference now is that it will arrive with a diagnostic dump attached instead of requiring another round of inference.

I also could not build this locally — Docker Desktop's daemon is not running on this machine — so the Dockerfile is validated only structurally: the embedded Python parses as valid code, the version extraction yields `2.5.1`, and the stage wiring is correct. The build itself is first exercised by CI.

Sources: [NumPy CPU build options](https://numpy.org/doc/stable/reference/simd/build-options.html)