### PR TITLE
Force a new flask pod so it picks up the mutable :latest tag

### DIFF
--- a/.github/workflows/deploy_kubernetes_resources.sh
+++ b/.github/workflows/deploy_kubernetes_resources.sh
@@ -30,9 +30,30 @@ echo "Kubernetes API server reachable - proceeding with the deploy."
 deploy_and_wait() {
   local name=$1
   local timeout=${2:-10m}
+  local force_restart=${3:-no}
 
   echo "Deploying ${name}..."
   kubectl apply -f "${KUBERNETES_DIR}/deployment/${name}-deployment.yml"
+
+  # A mutable tag does not roll a Deployment. flask is deployed as :latest, so once
+  # its spec has settled, `kubectl apply` is a no-op even though CI just pushed a new
+  # image under that tag -- Kubernetes compares the spec, not the registry digest.
+  #
+  # That is not hypothetical: a NumPy fix was built and pushed, and the node kept
+  # crash-looping the SAME pod for another 69 minutes (x324 restarts) on the old
+  # image, reporting a stale error that looked exactly like the fix having failed.
+  #
+  # rollout restart forces a new pod, which (imagePullPolicy: Always) pulls the
+  # current tag. Only for mutable-tag workloads: mongo and redis are pinned, and
+  # restarting the database on every deploy would be gratuitous.
+  #
+  # The better end state is deploying by immutable digest or the :${GITHUB_SHA} tag
+  # CI already publishes, so a rollout is driven by a real spec change. That needs
+  # image substitution at apply time and is deliberately left as a follow-up.
+  if [ "${force_restart}" = "restart" ]; then
+    echo "Forcing a new ${name} pod so it pulls the current mutable tag..."
+    kubectl rollout restart "deployment/${name}" -n aqra
+  fi
 
   local generation observed
   generation=$(kubectl get "deployment/${name}" -n aqra -o jsonpath='{.metadata.generation}')
@@ -67,5 +88,6 @@ kubectl apply -k ${KUBERNETES_DIR}
 deploy_and_wait mongo 10m
 deploy_and_wait redis 10m
 # Longer: flask's create_app() blocks on a bulk data fetch before the worker binds, and
-# its startupProbe allows 15 minutes for that.
-deploy_and_wait flask 20m
+# its startupProbe allows 15 minutes for that. "restart" because its image is the mutable
+# :latest tag -- see the note in deploy_and_wait.
+deploy_and_wait flask 20m restart


### PR DESCRIPTION
The NumPy fix in #21 built and pushed correctly. The node ran the old image anyway.

```
BackOff  4m6s (x324 over 69m)  ...  pod flask-7d46c9f95d-vj5pc
```

**Same pod, 69 minutes old.** It was created by #19's probe change at 15:07 and never replaced. flask is deployed as `:latest`, and Kubernetes compares the **Deployment spec, not the registry digest** — so once the spec has settled, `kubectl apply` is a no-op regardless of what CI just pushed under that tag.

That makes the failure actively misleading: the surviving pod keeps emitting the pre-fix `NumPy was built with baseline optimizations (X86_V2)` error, which reads exactly like #21 having failed. It had simply never been tried.

`reload_pods.sh` already exists to force this restart, but it never runs — the deploy script aborts under `set -e` at flask's rollout first.

## The fix

`deploy_and_wait` takes an optional `restart` argument and issues `kubectl rollout restart` for flask before waiting, so a new pod is created and pulls the current tag under `imagePullPolicy: Always`.

Only flask. mongo and redis are on pinned tags (`mongo:4.4`, `redis:8-alpine`), where a forced restart every deploy would be gratuitous — and for mongo, would needlessly bounce the database.

## The better end state, deliberately deferred

Deploying by immutable digest, or by the `:${GITHUB_SHA}` tag CI **already publishes**, so a rollout is driven by a genuine spec change rather than a forced restart. That removes the mutable-tag ambiguity entirely instead of working around it.

It needs image substitution at apply time — the Deployments are applied as static YAML from the node's checkout and aren't in `kustomization.yml` — so it is a real change to how every object is applied. Not something to bundle into the PR that is trying to get one container to start.

## Verification

`bash -n` passes and the three call sites are correct. The real check is the next deploy: a **new** pod name in the events, and `curl https://aqra.feit.ukim.edu.mk/api/v1/cities/` returning 200. If NumPy still fails after this, that will be the first time the fix has actually been exercised.