### PR TITLE
fix(k8s): pin the redis image to an exact patch

### DIFF
--- a/kubernetes/deployment/redis-deployment.yml
+++ b/kubernetes/deployment/redis-deployment.yml
@@ -21,7 +21,13 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: redis
-          image: redis:8-alpine
+          # Pinned to an exact patch, like every other image in this tree. `redis:8-alpine` is a
+          # FLOATING tag: it silently follows the 8 line, so two applies of the same manifest can
+          # land different builds and there is no version in git to roll back to. Nothing updates
+          # this file automatically -- Kubernetes manifests map to no Dependabot ecosystem, and the
+          # trial block that pointed `docker` at /kubernetes produced zero PRs and was removed --
+          # so bump it by hand when the base image moves.
+          image: redis:8.8.1-alpine
           imagePullPolicy: IfNotPresent
           # Used purely as a shared cache + rate-limit store, so persistence is off and
           # memory is bounded with LRU eviction (all keys carry TTLs).


### PR DESCRIPTION
`redis:8-alpine` was the one image left floating after the kubectl pin. A floating tag means two applies of the same manifest can land different builds, and there is no version in git to roll back to.

Pinned to `redis:8.8.1-alpine` (current 8-line patch on Docker Hub). The comment records that nothing updates this file automatically: Kubernetes manifests map to no Dependabot ecosystem, and the trial block that pointed the `docker` ecosystem at `/kubernetes` produced zero PRs over several runs and was removed as a config implying coverage it did not have. So this moves by hand.