### PR TITLE
feat: count what each batch job achieved, and say so when it ends

### DIFF
--- a/src/api/blueprints/__init__.py
+++ b/src/api/blueprints/__init__.py
@@ -9,6 +9,7 @@ from api.config.cache import cache
 from definitions import CACHE_TIMEOUTS, DATA_PROCESSED_PATH, DATA_RAW_PATH
 from preparation import check_api_lock, fetch_weather_data
 from processing import read_csv_in_chunks
+from utils import BatchOutcome
 
 logger = getLogger(__name__)
 
@@ -52,8 +53,18 @@ def create_data_paths(city_name: str, sensor_id: str) -> None:
     (DATA_PROCESSED_PATH / city_name / sensor_id).mkdir(parents=True, exist_ok=True)
 
 
-def fetch_city_data(city_name: str, sensor: dict) -> None:
-    if check_api_lock():
-        return
+def fetch_city_data(city_name: str, sensor: dict) -> BatchOutcome:
+    # `check_api_lock()` is `not lock_file.exists()`, so True means UNLOCKED -- the API is
+    # available and this should proceed. The guard was `if check_api_lock(): return`, the
+    # exact inverse of the one its only caller uses (`fetch_hourly_data` bails on `not
+    # check_api_lock()`), so this returned immediately whenever OpenWeather was callable
+    # and was only reached when the outer job had already bailed. It fetched nothing under
+    # either condition. Skipping is the LOCKED case, which is what this now says.
+    if not check_api_lock():
+        return BatchOutcome.SKIPPED
     create_data_paths(city_name, sensor["sensorId"])
-    fetch_weather_data(city_name, sensor)
+    return (
+        BatchOutcome.DONE
+        if fetch_weather_data(city_name, sensor)
+        else BatchOutcome.FAILED
+    )

--- a/src/api/config/environment.py
+++ b/src/api/config/environment.py
@@ -17,6 +17,7 @@ from definitions import (
 )
 from preparation import read_cities, read_sensors
 from processing import find_missing_data, read_csv_in_chunks, save_dataframe
+from utils import BatchOutcome, BatchTally
 from .repository import RepositorySingleton
 from .schedule import fetch_locations
 
@@ -47,7 +48,7 @@ def init_environment_variables() -> None:
 
 
 # TODO: Review this method for inserting duplicate values
-def fetch_collection(collection: str, city_name: str, sensor_id: str) -> None:
+def fetch_collection(collection: str, city_name: str, sensor_id: str) -> BatchOutcome:
     db_records = DataFrame(
         repository.get_many(
             collection_name=collection,
@@ -56,7 +57,7 @@ def fetch_collection(collection: str, city_name: str, sensor_id: str) -> None:
         )
     )
     if db_records.empty:
-        return
+        return BatchOutcome.SKIPPED
 
     collection_dir = DATA_RAW_PATH / city_name / sensor_id
     collection_dir.mkdir(parents=True, exist_ok=True)
@@ -73,29 +74,39 @@ def fetch_collection(collection: str, city_name: str, sensor_id: str) -> None:
 
         save_dataframe(dataframe, collection, collection_path, sensor_id)
         del dataframe
+        return BatchOutcome.DONE
     except Exception:
         logger.exception(
             f"Could not fetch data from local storage for {city_name} - {sensor_id} - {collection}",
         )
         # TODO: Review this line for converting column data types
         # db_records = db_records.astype(column_dtypes, errors="ignore")
+        # The records are still written, straight from the database rather than merged
+        # with local storage, so this is a degraded write and not a lost one -- but it is
+        # reported as FAILED because the merge it was asked to do did not happen.
         db_records.to_csv(collection_path, index=False)
+        return BatchOutcome.FAILED
     finally:
         del db_records
         collect()
 
 
 def fetch_db_data() -> None:
-    for city in read_cities():
-        for sensor in read_sensors(city["cityName"]):
-            for collection in COLLECTIONS:
-                try:
-                    fetch_collection(collection, city["cityName"], sensor["sensorId"])
-                except Exception:
-                    logger.exception(
-                        f"Could not fetch data from the database for {city['cityName']} - {sensor['sensorId']} - "
-                        f"{collection}",
-                    )
+    with BatchTally(logger, "fetch_db_data", "collection") as tally:
+        for city in read_cities():
+            for sensor in read_sensors(city["cityName"]):
+                for collection in tally.track(COLLECTIONS):
+                    try:
+                        tally.record(
+                            fetch_collection(
+                                collection, city["cityName"], sensor["sensorId"]
+                            )
+                        )
+                    except Exception:
+                        tally.failure(
+                            f"Could not fetch data from the database for {city['cityName']} - "
+                            f"{sensor['sensorId']} - {collection}",
+                        )
 
 
 def init_data() -> None:

--- a/src/api/config/schedule.py
+++ b/src/api/config/schedule.py
@@ -39,7 +39,7 @@ from processing import (
     read_csv_in_chunks,
     save_dataframe,
 )
-from utils import track_time
+from utils import BatchTally, track_time
 from .cache import cache
 from .dump import generate_sql_dump
 from .git import append_commit_files, create_archive, update_git_files
@@ -114,18 +114,33 @@ def dump_jobs() -> None:
 @track_time
 def fetch_hourly_data() -> None:
     if not check_api_lock():
+        logger.warning(
+            "fetch_hourly_data: the OpenWeather API is locked; nothing fetched"
+        )
         return
-    for city in cache.get("cities") or read_cities():
-        for sensor in read_sensors(city["cityName"]):
-            fetch_city_data(city["cityName"], sensor)
-            for collection in COLLECTIONS:
-                if (
-                    DATA_RAW_PATH
-                    / city["cityName"]
-                    / sensor["sensorId"]
-                    / f"{collection}.csv"
-                ).exists():
-                    process_data(city["cityName"], sensor["sensorId"], collection)
+    # Two tallies, because the two halves fail for unrelated reasons and a single number
+    # would hide which one. An upstream outage empties the first; a processing defect
+    # empties the second while the fetch keeps working.
+    with (
+        BatchTally(logger, "fetch_hourly_data (fetch)", "sensor") as fetched,
+        BatchTally(logger, "fetch_hourly_data (process)", "collection") as processed,
+    ):
+        for city in cache.get("cities") or read_cities():
+            for sensor in fetched.track(read_sensors(city["cityName"])):
+                fetched.record(fetch_city_data(city["cityName"], sensor))
+                for collection in COLLECTIONS:
+                    if (
+                        DATA_RAW_PATH
+                        / city["cityName"]
+                        / sensor["sensorId"]
+                        / f"{collection}.csv"
+                    ).exists():
+                        processed.attempt()
+                        processed.record(
+                            process_data(
+                                city["cityName"], sensor["sensorId"], collection
+                            )
+                        )
 
 
 @scheduler.scheduled_job(
@@ -145,17 +160,18 @@ def fetch_locations() -> None:
         logger.warning(
             "Upstream returned no countries; keeping the stored list rather than emptying it",
         )
-    for country in countries:
-        try:
-            repository.save(
-                collection_name="countries",
-                filter={"countryCode": country["countryCode"]},
-                item=country,
-            )
-        except Exception:
-            logger.exception(
-                f"Error occurred while updating data for {country['countryName']}",
-            )
+    with BatchTally(logger, "fetch_locations (countries)", "country") as tally:
+        for country in tally.track(countries):
+            try:
+                repository.save(
+                    collection_name="countries",
+                    filter={"countryCode": country["countryCode"]},
+                    item=country,
+                )
+            except Exception:
+                tally.failure(
+                    f"Error occurred while updating data for {country['countryName']}",
+                )
 
     # fetch_countries / fetch_cities / fetch_sensors each answer an upstream failure with an
     # empty list, so writing the result straight to disk turns a transient pulse.eco outage
@@ -171,39 +187,43 @@ def fetch_locations() -> None:
         logger.warning(
             "Upstream returned no cities; keeping the stored list rather than emptying it",
         )
-    for city in cities:
-        try:
-            repository.save(
-                collection_name="cities",
-                filter={"cityName": city["cityName"]},
-                item=city,
-            )
-        except Exception:
-            logger.exception(
-                f"Error occurred while updating data for {city['cityName']}",
-            )
-        sensors = fetch_sensors(city["cityName"])
-        for sensor in sensors:
-            sensor["cityName"] = city["cityName"]
+    with (
+        BatchTally(logger, "fetch_locations (cities)", "city", "cities") as city_tally,
+        BatchTally(logger, "fetch_locations (sensors)", "sensor") as sensor_tally,
+    ):
+        for city in city_tally.track(cities):
             try:
                 repository.save(
-                    collection_name="sensors",
-                    filter={"sensorId": sensor["sensorId"]},
-                    item=sensor,
+                    collection_name="cities",
+                    filter={"cityName": city["cityName"]},
+                    item=city,
                 )
             except Exception:
-                logger.exception(
-                    f"Error occurred while updating data for {sensor['sensorId']}",
+                city_tally.failure(
+                    f"Error occurred while updating data for {city['cityName']}",
                 )
-        if sensors:
-            (DATA_RAW_PATH / city["cityName"]).mkdir(parents=True, exist_ok=True)
-            (DATA_RAW_PATH / city["cityName"] / "sensors.json").write_text(
-                dumps(sensors, indent=4)
-            )
-        else:
-            logger.warning(
-                f"Upstream returned no sensors for {city['cityName']}; keeping the stored list",
-            )
+            sensors = fetch_sensors(city["cityName"])
+            for sensor in sensor_tally.track(sensors):
+                sensor["cityName"] = city["cityName"]
+                try:
+                    repository.save(
+                        collection_name="sensors",
+                        filter={"sensorId": sensor["sensorId"]},
+                        item=sensor,
+                    )
+                except Exception:
+                    sensor_tally.failure(
+                        f"Error occurred while updating data for {sensor['sensorId']}",
+                    )
+            if sensors:
+                (DATA_RAW_PATH / city["cityName"]).mkdir(parents=True, exist_ok=True)
+                (DATA_RAW_PATH / city["cityName"] / "sensors.json").write_text(
+                    dumps(sensors, indent=4)
+                )
+            else:
+                logger.warning(
+                    f"Upstream returned no sensors for {city['cityName']}; keeping the stored list",
+                )
 
 
 @scheduler.scheduled_job(
@@ -222,25 +242,27 @@ def import_data() -> None:
                 unpack_archive(filename=str(file_path), extract_dir=root, format=fmt)
                 file_path.unlink(missing_ok=True)
 
-    for root, directories, files in walk(DATA_EXTERNAL_PATH):
-        for file in files:
-            if file.endswith(".csv"):
-                file_path = Path(root) / file
-                try:
-                    dataframe = read_csv_in_chunks(file_path)
-                    save_dataframe(
-                        dataframe,
-                        Path(file).stem,
-                        DATA_RAW_PATH / file_path.relative_to(DATA_EXTERNAL_PATH),
-                        file_path.parent.name,
-                    )
-                    file_path.unlink(missing_ok=True)
-                except Exception:
-                    logger.exception(
-                        f"Error occurred while importing data from {file_path}",
-                    )
-        if not directories and not files:
-            Path(root).rmdir()
+    with BatchTally(logger, "import_data", "file") as tally:
+        for root, directories, files in walk(DATA_EXTERNAL_PATH):
+            for file in files:
+                if file.endswith(".csv"):
+                    file_path = Path(root) / file
+                    tally.attempt()
+                    try:
+                        dataframe = read_csv_in_chunks(file_path)
+                        save_dataframe(
+                            dataframe,
+                            Path(file).stem,
+                            DATA_RAW_PATH / file_path.relative_to(DATA_EXTERNAL_PATH),
+                            file_path.parent.name,
+                        )
+                        file_path.unlink(missing_ok=True)
+                    except Exception:
+                        tally.failure(
+                            f"Error occurred while importing data from {file_path}",
+                        )
+            if not directories and not files:
+                Path(root).rmdir()
 
     DATA_EXTERNAL_PATH.mkdir(parents=True, exist_ok=True)
 
@@ -254,10 +276,11 @@ def import_data() -> None:
 )
 @track_time
 def model_training() -> None:
-    for city in cache.get("cities") or read_cities():
-        for sensor in read_sensors(city["cityName"]):
-            for pollutant in POLLUTANTS:
-                train_regression_model(city, sensor, pollutant)
+    with BatchTally(logger, "model_training", "model") as tally:
+        for city in cache.get("cities") or read_cities():
+            for sensor in read_sensors(city["cityName"]):
+                for pollutant in tally.track(POLLUTANTS):
+                    tally.record(train_regression_model(city, sensor, pollutant))
 
 
 @scheduler.scheduled_job(
@@ -269,48 +292,51 @@ def model_training() -> None:
 )
 @track_time
 def predict_locations() -> None:
-    for city in cache.get("cities") or read_cities():
-        for sensor in read_sensors(city["cityName"]):
-            file_path = (
-                DATA_PROCESSED_PATH
-                / city["cityName"]
-                / sensor["sensorId"]
-                / "predictions.json"
-            )
-            try:
-                repository.save(
-                    collection_name="predictions",
-                    filter={
-                        "cityName": city["cityName"],
-                        "sensorId": sensor["sensorId"],
-                    },
-                    item={
-                        "data": loads(file_path.read_text()),
-                        "cityName": city["cityName"],
-                        "sensorId": sensor["sensorId"],
-                    },
-                )
-            except Exception:
-                logger.exception(
-                    f"Error occurred while updating forecast values from {file_path}",
-                )
-
-    for city in cache.get("cities") or read_cities():
-        for sensor in read_sensors(city["cityName"]):
-            try:
-                forecast_result = fetch_forecast_result(city, sensor)
-                (
+    with BatchTally(logger, "predict_locations (publish)", "sensor") as tally:
+        for city in cache.get("cities") or read_cities():
+            for sensor in tally.track(read_sensors(city["cityName"])):
+                file_path = (
                     DATA_PROCESSED_PATH
                     / city["cityName"]
                     / sensor["sensorId"]
                     / "predictions.json"
-                ).write_text(
-                    dumps(list(forecast_result.values()), indent=4, default=str)
                 )
-            except Exception:
-                logger.exception(
-                    f"Error occurred while fetching forecast values for {city['cityName']} - {sensor['sensorId']}",
-                )
+                try:
+                    repository.save(
+                        collection_name="predictions",
+                        filter={
+                            "cityName": city["cityName"],
+                            "sensorId": sensor["sensorId"],
+                        },
+                        item={
+                            "data": loads(file_path.read_text()),
+                            "cityName": city["cityName"],
+                            "sensorId": sensor["sensorId"],
+                        },
+                    )
+                except Exception:
+                    tally.failure(
+                        f"Error occurred while updating forecast values from {file_path}",
+                    )
+
+    with BatchTally(logger, "predict_locations (forecast)", "sensor") as tally:
+        for city in cache.get("cities") or read_cities():
+            for sensor in tally.track(read_sensors(city["cityName"])):
+                try:
+                    forecast_result = fetch_forecast_result(city, sensor)
+                    (
+                        DATA_PROCESSED_PATH
+                        / city["cityName"]
+                        / sensor["sensorId"]
+                        / "predictions.json"
+                    ).write_text(
+                        dumps(list(forecast_result.values()), indent=4, default=str)
+                    )
+                except Exception:
+                    tally.failure(
+                        f"Error occurred while fetching forecast values for "
+                        f"{city['cityName']} - {sensor['sensorId']}",
+                    )
 
 
 @scheduler.scheduled_job(

--- a/src/modeling/train_model.py
+++ b/src/modeling/train_model.py
@@ -31,7 +31,7 @@ from processing import (
     fetch_summary_dataframe,
     value_scaling,
 )
-from utils import track_time
+from utils import BatchOutcome, track_time
 from visualization import draw_errors, draw_predictions
 from .process_results import save_errors, save_results
 
@@ -237,7 +237,7 @@ def setup_model(
 
 
 @track_time
-def train_regression_model(city: dict, sensor: dict, pollutant: str) -> None:
+def train_regression_model(city: dict, sensor: dict, pollutant: str) -> BatchOutcome:
     logger.info(
         f"Training model for {city['cityName']} - {sensor['sensorId']} - {pollutant}"
     )
@@ -246,7 +246,7 @@ def train_regression_model(city: dict, sensor: dict, pollutant: str) -> None:
         logger.info(
             f"Skipped training model for {city['cityName']} - {sensor['sensorId']} - {pollutant}"
         )
-        return
+        return BatchOutcome.SKIPPED
     try:
         dataframe = fetch_summary_dataframe(
             DATA_PROCESSED_PATH / city["cityName"] / sensor["sensorId"],
@@ -255,7 +255,11 @@ def train_regression_model(city: dict, sensor: dict, pollutant: str) -> None:
         dataframe = dataframe.loc[
             dataframe.index <= to_datetime(datetime.now(UTC)).to_datetime64()
         ]
-        if pollutant in dataframe.columns:
+        # A sensor that never reported this pollutant has nothing to train on. That is
+        # not a completed training run, and it used to log as one -- the "Completed"
+        # message below fired either way.
+        trained = pollutant in dataframe.columns
+        if trained:
             create_pollutant_lock(data_path)
             generate_regression_model(
                 dataframe, city["cityName"], sensor["sensorId"], pollutant
@@ -265,14 +269,23 @@ def train_regression_model(city: dict, sensor: dict, pollutant: str) -> None:
 
         del dataframe
 
+        if trained:
+            logger.info(
+                f"Completed training model for {city['cityName']} - {sensor['sensorId']} - {pollutant}"
+            )
+            return BatchOutcome.DONE
+
         logger.info(
-            f"Completed training model for {city['cityName']} - {sensor['sensorId']} - {pollutant}"
+            f"No {pollutant} readings for {city['cityName']} - {sensor['sensorId']}; "
+            f"nothing to train"
         )
+        return BatchOutcome.SKIPPED
     except Exception:
         logger.exception(
             f"Error occurred while training model for {city['cityName']} - "
             f"{sensor['sensorId']} - {pollutant}",
         )
+        return BatchOutcome.FAILED
     finally:
         remove_pollutant_lock(data_path)
         collect()

--- a/src/preparation/weather_data.py
+++ b/src/preparation/weather_data.py
@@ -22,7 +22,7 @@ def check_api_lock() -> bool:
     return not (DATA_PATH / f"{OPEN_WEATHER}.lock").exists()
 
 
-def fetch_dark_sky_data(city_name: str, sensor: dict) -> None:
+def fetch_dark_sky_data(city_name: str, sensor: dict) -> bool:
     token = environ[DARK_SKY_TOKEN]
     url = f"https://api.darksky.net/forecast/{token}/{sensor['position']}"
     exclude = "currently,minutely,daily,alerts,flags"
@@ -43,16 +43,18 @@ def fetch_dark_sky_data(city_name: str, sensor: dict) -> None:
                 sensor["sensorId"],
             )
         del dataframe
+        return True
     except Exception:
         logger.exception(
             f"Error occurred while fetching DarkSky data for {city_name} - {sensor['sensorId']}",
         )
+        return False
     finally:
         collect()
         sleep(1)
 
 
-def fetch_open_weather_data(city_name: str, sensor: dict) -> None:
+def fetch_open_weather_data(city_name: str, sensor: dict) -> bool:
     url = "https://api.openweathermap.org/data/3.0/onecall"
     sensor_position = sensor["position"].split(",")
     lat, lon = float(sensor_position[0]), float(sensor_position[1])
@@ -79,16 +81,18 @@ def fetch_open_weather_data(city_name: str, sensor: dict) -> None:
                 sensor["sensorId"],
             )
         del dataframe
+        return True
     except Exception:
         logger.exception(
             f"Error occurred while fetching Open Weather data for {city_name} - {sensor['sensorId']}",
         )
+        return False
     finally:
         collect()
         sleep(1)
 
 
-def fetch_pollution_data(city_name: str, sensor: dict) -> None:
+def fetch_pollution_data(city_name: str, sensor: dict) -> bool:
     url = "https://api.openweathermap.org/data/2.5/air_pollution/forecast"
     sensor_position = sensor["position"].split(",")
     lat, lon = float(sensor_position[0]), float(sensor_position[1])
@@ -119,18 +123,24 @@ def fetch_pollution_data(city_name: str, sensor: dict) -> None:
                 sensor["sensorId"],
             )
         del dataframe
+        return True
     except Exception:
         logger.exception(
             f"Error occurred while fetching pollution data for {city_name} - {sensor["sensorId"]}",
         )
+        return False
     finally:
         collect()
         sleep(1)
 
 
-def fetch_weather_data(city_name: str, sensor: dict) -> None:
-    fetch_open_weather_data(city_name, sensor)
-    fetch_pollution_data(city_name, sensor)
+def fetch_weather_data(city_name: str, sensor: dict) -> bool:
+    # Both calls run whatever the first one does -- they fetch different collections and a
+    # weather failure is no reason to skip pollution. Hence the two names rather than
+    # `and`, which would short-circuit.
+    weather_ok = fetch_open_weather_data(city_name, sensor)
+    pollution_ok = fetch_pollution_data(city_name, sensor)
+    return weather_ok and pollution_ok
 
 
 def lock_api() -> None:

--- a/src/processing/normalize_data.py
+++ b/src/processing/normalize_data.py
@@ -8,6 +8,7 @@ from scipy.stats import zscore
 from sklearn.impute import KNNImputer
 
 from definitions import DATA_PROCESSED_PATH, DATA_RAW_PATH, POLLUTANTS
+from utils import BatchOutcome
 from .calculate_index import calculate_aqi, calculate_index
 from .handle_data import (
     drop_unnecessary_features,
@@ -114,7 +115,7 @@ def next_hour(t: datetime, tz: tzinfo = None) -> datetime:
 
 
 # TODO: Refactor this method to reduce number of exceptions based on missing dataset
-def process_data(city_name: str, sensor_id: str, collection: str) -> None:
+def process_data(city_name: str, sensor_id: str, collection: str) -> BatchOutcome:
     try:
         dataframe_raw = read_csv_in_chunks(
             DATA_RAW_PATH / city_name / sensor_id / f"{collection}.csv"
@@ -138,7 +139,7 @@ def process_data(city_name: str, sensor_id: str, collection: str) -> None:
         dataframe_raw = drop_unnecessary_features(dataframe_raw)
         dataframe_raw = trim_dataframe(dataframe_raw, "time")
         if len(dataframe_raw.index) == 0:
-            return
+            return BatchOutcome.SKIPPED
 
         df_columns = dataframe_raw.columns.copy()
         df_columns = df_columns.drop(
@@ -192,8 +193,15 @@ def process_data(city_name: str, sensor_id: str, collection: str) -> None:
                 index=False,
                 mode="a",
             )
+            return BatchOutcome.DONE
+
+        # Everything new was already present downstream, so there was nothing to write.
+        # Reported apart from DONE so a run that processed no new readings at all is
+        # visible as such rather than as a run that processed everything.
+        return BatchOutcome.SKIPPED
 
     except Exception:
         logger.exception(
             f"Error occurred while processing {collection} data for {city_name} - {sensor_id}",
         )
+        return BatchOutcome.FAILED

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,8 +1,128 @@
 import time
+from enum import Enum
 from functools import wraps
 from logging import getLogger
+from typing import Iterable, Iterator
 
 logger = getLogger(__name__)
+
+
+class BatchOutcome(Enum):
+    """What one unit of work in a batch job achieved.
+
+    Returned by the functions that isolate their own failures, so the loop driving them
+    can tell the three apart. A bare ``bool`` cannot: "nothing to do" and "it worked" are
+    both truthy, and conflating them is how a job that trained no models at all reports
+    the same thing as one that trained every model it had.
+    """
+
+    DONE = "done"
+    SKIPPED = "skipped"
+    FAILED = "failed"
+
+
+class BatchTally:
+    """Counts what a batch job actually achieved and says so when the loop ends.
+
+    Every loop in this project isolates its items: one bad sensor is logged and the run
+    moves on to the next one. That is the right behaviour and it stays. But it means a job
+    in which every single item failed finishes exactly like a job in which every item
+    succeeded -- neither raises, both exit 0, and the only difference is a pile of
+    tracebacks that nothing was counting.
+
+    It is a context manager so the summary cannot be forgotten, and so that it survives
+    the job raising partway through::
+
+        with BatchTally(logger, "fetch_locations", "country") as tally:
+            for country in tally.track(countries):
+                try:
+                    ...
+                except Exception:
+                    tally.failure(f"Could not update {country['countryName']}")
+
+    A context manager rather than a self-summarising generator, specifically because the
+    loops here nest -- city, then sensor, then collection. ``track`` on the innermost
+    iterable is re-entered once per sensor, so a generator that summarised on exhaustion
+    would fire once per sensor rather than once per job. ``__exit__`` fires exactly once
+    however deep the nesting goes.
+
+    Severity escalates with the damage: a clean run is ``info``, some failures are
+    ``warning``, and *everything* failing is ``error``, because a job that achieved
+    nothing is a different event from a job that dropped one sensor.
+    """
+
+    def __init__(self, log, job: str, unit: str, plural: str = None):
+        self._logger = log
+        self._job = job
+        self._unit = unit
+        # Passed rather than derived. A `unit + "s"` rule renders "city" as "citys", and
+        # the fix for that is a pluralisation function that will be wrong about the next
+        # word instead. One optional argument at three call sites is cheaper and correct.
+        self._plural = plural or f"{unit}s"
+        self._summarised = False
+        self.total = 0
+        self.failures = 0
+        self.skipped = 0
+
+    def __enter__(self) -> "BatchTally":
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> bool:
+        # Summarise even when the job is unwinding: "died after 12 of 400 sensors" is the
+        # most useful line in that log, and it is the one that would go missing.
+        self.summarise()
+        return False
+
+    @property
+    def done(self) -> int:
+        return self.total - self.failures - self.skipped
+
+    def track(self, items: Iterable) -> Iterator:
+        """Yield each item, counting it as attempted."""
+        for item in items:
+            self.attempt()
+            yield item
+
+    def attempt(self) -> None:
+        """Count one unit, for a loop whose iterable is not the unit being tallied."""
+        self.total += 1
+
+    def failure(self, message: str) -> None:
+        """Log the exception being handled and count the unit as failed."""
+        self._logger.exception(message)
+        self.failures += 1
+
+    def record(self, outcome: BatchOutcome) -> None:
+        """Count an outcome a callee already decided (and already logged)."""
+        if outcome is BatchOutcome.FAILED:
+            self.failures += 1
+        elif outcome is BatchOutcome.SKIPPED:
+            self.skipped += 1
+
+    def summarise(self) -> None:
+        """Emit the one line that says whether this job accomplished anything."""
+        if self._summarised:
+            return
+        self._summarised = True
+
+        unit = self._unit if self.total == 1 else self._plural
+        if not self.total:
+            self._logger.info(f"{self._job}: no {unit} to process")
+            return
+
+        detail = f"{self.done} done, {self.failures} failed"
+        if self.skipped:
+            detail += f", {self.skipped} skipped"
+        summary = f"{self._job}: {self.total} {unit} -- {detail}"
+
+        if not self.failures:
+            self._logger.info(summary)
+        elif self.failures == self.total:
+            # Not a warning. Every unit failing means the job achieved nothing, which is
+            # the case this class exists to make visible.
+            self._logger.error(f"{summary} (every {self._unit} failed)")
+        else:
+            self._logger.warning(summary)
 
 
 def format_duration(seconds):

--- a/tests/test_batch_tally.py
+++ b/tests/test_batch_tally.py
@@ -1,0 +1,185 @@
+"""Tests for ``utils.BatchTally`` — the end-of-job line that says what a batch achieved.
+
+Every scheduled job here isolates its items: one bad sensor is logged and the run moves
+on. That is correct and it stays. The consequence is that a job in which every item failed
+finishes exactly like a job in which every item succeeded — neither raises, both exit 0,
+and the only difference is a pile of tracebacks nothing was counting.
+
+So the assertions below are mostly about **severity**, not arithmetic. Getting the counts
+right and logging them all at ``info`` would leave the situation exactly as it was: a line
+nobody reads. The escalation to ``error`` when everything failed is the feature.
+"""
+
+from logging import getLogger
+
+import pytest
+
+from utils import BatchOutcome, BatchTally
+
+_LOGGER_NAME = "tests.batch_tally"
+
+
+@pytest.fixture
+def log():
+    return getLogger(_LOGGER_NAME)
+
+
+def _summary(caplog):
+    """The single summary record, asserting there is exactly one."""
+    records = [r for r in caplog.records if r.name == _LOGGER_NAME]
+    assert len(records) == 1, f"expected one summary, got {len(records)}"
+    return records[0]
+
+
+def test_reports_an_empty_batch_as_having_nothing_to_do(log, caplog):
+    # Distinct from "everything failed" on purpose: a job with no work is not a broken job,
+    # and collapsing the two is what makes an alert on this line useless.
+    with caplog.at_level("INFO", logger=_LOGGER_NAME):
+        with BatchTally(log, "fetch_locations", "city", "cities") as tally:
+            for _ in tally.track([]):
+                pass
+
+    record = _summary(caplog)
+    assert record.levelname == "INFO"
+    assert "no cities to process" in record.message
+
+
+def test_reports_a_clean_run_at_info(log, caplog):
+    with caplog.at_level("INFO", logger=_LOGGER_NAME):
+        with BatchTally(log, "fetch_locations", "city", "cities") as tally:
+            for _ in tally.track(["skopje", "bitola", "ohrid"]):
+                pass
+
+    record = _summary(caplog)
+    assert record.levelname == "INFO"
+    assert "3 cities" in record.message
+    assert "3 done, 0 failed" in record.message
+
+
+def test_reports_a_partial_failure_at_warning(log, caplog):
+    with caplog.at_level("INFO", logger=_LOGGER_NAME):
+        with BatchTally(log, "fetch_locations", "city", "cities") as tally:
+            for city in tally.track(["skopje", "bitola", "ohrid"]):
+                if city == "bitola":
+                    try:
+                        raise RuntimeError("upstream refused")
+                    except RuntimeError:
+                        tally.failure(f"Could not update {city}")
+
+    records = [r for r in caplog.records if r.name == _LOGGER_NAME]
+    # The per-item traceback and the summary: the summary replaces neither.
+    assert len(records) == 2
+    failure, summary = records
+    assert failure.levelname == "ERROR"
+    assert failure.exc_info is not None, "the per-item traceback must survive"
+    assert summary.levelname == "WARNING"
+    assert "2 done, 1 failed" in summary.message
+
+
+def test_escalates_to_error_when_every_unit_failed(log, caplog):
+    # The whole point. A job that achieved nothing is a different event from a job that
+    # dropped one sensor, and only this line can say so.
+    with caplog.at_level("INFO", logger=_LOGGER_NAME):
+        with BatchTally(log, "fetch_locations", "city", "cities") as tally:
+            for city in tally.track(["skopje", "bitola"]):
+                try:
+                    raise RuntimeError("upstream is down")
+                except RuntimeError:
+                    tally.failure(f"Could not update {city}")
+
+    summary = [r for r in caplog.records if r.name == _LOGGER_NAME][-1]
+    assert summary.levelname == "ERROR"
+    assert "0 done, 2 failed" in summary.message
+    assert "every city failed" in summary.message
+
+
+def test_counts_skipped_units_apart_from_done_ones(log, caplog):
+    # "47 models, 0 failed" reads as success while every one of them was skipped. Keeping
+    # skips in their own column is what stops that.
+    with caplog.at_level("INFO", logger=_LOGGER_NAME):
+        with BatchTally(log, "model_training", "model") as tally:
+            for outcome in tally.track(
+                [BatchOutcome.DONE, BatchOutcome.SKIPPED, BatchOutcome.SKIPPED]
+            ):
+                tally.record(outcome)
+
+    summary = _summary(caplog)
+    assert summary.levelname == "INFO"
+    assert "1 done, 0 failed, 2 skipped" in summary.message
+
+
+def test_record_counts_a_failure_a_callee_already_logged(log, caplog):
+    # `record` must not log again: the callee that returned FAILED already wrote the
+    # traceback, and a second copy makes the log harder to read, not more informative.
+    with caplog.at_level("INFO", logger=_LOGGER_NAME):
+        with BatchTally(log, "model_training", "model") as tally:
+            for outcome in tally.track([BatchOutcome.FAILED, BatchOutcome.DONE]):
+                tally.record(outcome)
+
+    summary = _summary(caplog)
+    assert summary.levelname == "WARNING"
+    assert "1 done, 1 failed" in summary.message
+
+
+def test_summarises_when_the_job_dies_partway_through(log, caplog):
+    # "died after 12 of 400 sensors" is the most useful line in that log, and it is exactly
+    # the one an explicit call after the loop would lose.
+    with caplog.at_level("INFO", logger=_LOGGER_NAME):
+        with pytest.raises(RuntimeError):
+            with BatchTally(log, "import_data", "file") as tally:
+                for index in tally.track(range(10)):
+                    if index == 3:
+                        raise RuntimeError("the disk went away")
+
+    summary = _summary(caplog)
+    assert "4 files" in summary.message
+
+
+def test_summarises_once_even_if_asked_twice(log, caplog):
+    with caplog.at_level("INFO", logger=_LOGGER_NAME):
+        with BatchTally(log, "import_data", "file") as tally:
+            for _ in tally.track(["a.csv"]):
+                pass
+            tally.summarise()
+
+    _summary(caplog)  # asserts exactly one record
+
+
+def test_uses_the_singular_for_a_single_unit(log, caplog):
+    with caplog.at_level("INFO", logger=_LOGGER_NAME):
+        with BatchTally(log, "import_data", "file") as tally:
+            for _ in tally.track(["only.csv"]):
+                pass
+
+    assert "1 file --" in _summary(caplog).message
+
+
+def test_attempt_counts_a_unit_that_is_not_the_loop_variable(log, caplog):
+    # fetch_hourly_data tallies collections while looping over sensors, so the unit and the
+    # iterable are different things.
+    with caplog.at_level("INFO", logger=_LOGGER_NAME):
+        with BatchTally(log, "fetch_hourly_data", "collection") as tally:
+            for _ in ["sensor-1", "sensor-2"]:
+                for _ in ["weather", "pollution"]:
+                    tally.attempt()
+                    tally.record(BatchOutcome.DONE)
+
+    assert "4 collections" in _summary(caplog).message
+
+
+def test_the_plural_is_passed_not_guessed(log, caplog):
+    # A `unit + "s"` rule renders "city" as "citys". The default still applies to the
+    # regular units, which is why both halves are pinned here rather than only the
+    # irregular one.
+    with caplog.at_level("INFO", logger=_LOGGER_NAME):
+        with BatchTally(log, "fetch_locations", "city", "cities") as tally:
+            for _ in tally.track(["skopje", "bitola"]):
+                pass
+    assert "2 cities" in _summary(caplog).message
+
+    caplog.clear()
+    with caplog.at_level("INFO", logger=_LOGGER_NAME):
+        with BatchTally(log, "import_data", "file") as tally:
+            for _ in tally.track(["a.csv", "b.csv"]):
+                pass
+    assert "2 files" in _summary(caplog).message

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -26,6 +26,7 @@ import api.config  # noqa: F401
 from api import blueprints
 from api.blueprints import fetch_dataframe
 from api.config.cache import cache
+from utils import BatchOutcome
 
 _CSV = "time,pm2_5\n1704067200,12.0\n1704070800,13.0\n"
 
@@ -195,3 +196,65 @@ def test_returns_an_empty_forecast_when_neither_source_has_one(
     forecast = view.return_sensor_forecast_results(_FORECAST_CITY, _FORECAST_SENSOR)
 
     assert forecast["data"] == []
+
+
+# --- api.blueprints.fetch_city_data -------------------------------------------------
+
+
+def test_fetch_city_data_fetches_when_the_api_is_unlocked(monkeypatch, tmp_path):
+    """The guard was inverted, so this never fetched anything.
+
+    ``check_api_lock()`` is ``not lock_file.exists()`` -- True means UNLOCKED. The guard
+    read ``if check_api_lock(): return``, the exact inverse of the one in its only caller
+    (``fetch_hourly_data`` bails on ``not check_api_lock()``). So it returned immediately
+    whenever OpenWeather was callable, and was only ever reached when the outer job had
+    already bailed: it fetched nothing under either condition.
+
+    Nothing failed and nothing raised, which is why it survived. The tally in
+    ``fetch_hourly_data`` is what would have shown it -- every sensor skipped, every run.
+    """
+    monkeypatch.setattr(blueprints, "DATA_RAW_PATH", tmp_path / "raw")
+    monkeypatch.setattr(blueprints, "DATA_PROCESSED_PATH", tmp_path / "processed")
+    monkeypatch.setattr(blueprints, "check_api_lock", lambda: True)  # unlocked
+    calls = []
+    monkeypatch.setattr(
+        blueprints,
+        "fetch_weather_data",
+        lambda city_name, sensor: calls.append((city_name, sensor["sensorId"])) or True,
+    )
+
+    outcome = blueprints.fetch_city_data("skopje", {"sensorId": "1000"})
+
+    assert calls == [("skopje", "1000")], "an unlocked API must actually be fetched"
+    assert outcome is BatchOutcome.DONE
+
+
+def test_fetch_city_data_skips_when_the_api_is_locked(monkeypatch, tmp_path):
+    monkeypatch.setattr(blueprints, "DATA_RAW_PATH", tmp_path / "raw")
+    monkeypatch.setattr(blueprints, "DATA_PROCESSED_PATH", tmp_path / "processed")
+    monkeypatch.setattr(blueprints, "check_api_lock", lambda: False)  # locked
+    calls = []
+    monkeypatch.setattr(
+        blueprints,
+        "fetch_weather_data",
+        lambda city_name, sensor: calls.append(sensor) or True,
+    )
+
+    outcome = blueprints.fetch_city_data("skopje", {"sensorId": "1000"})
+
+    assert calls == [], "a locked API must not be called"
+    # SKIPPED, not DONE: a run that fetched nothing because the quota is spent is not a
+    # successful run, and the tally has to be able to say which it was.
+    assert outcome is BatchOutcome.SKIPPED
+
+
+def test_fetch_city_data_reports_a_failed_fetch(monkeypatch, tmp_path):
+    monkeypatch.setattr(blueprints, "DATA_RAW_PATH", tmp_path / "raw")
+    monkeypatch.setattr(blueprints, "DATA_PROCESSED_PATH", tmp_path / "processed")
+    monkeypatch.setattr(blueprints, "check_api_lock", lambda: True)
+    monkeypatch.setattr(blueprints, "fetch_weather_data", lambda *args: False)
+
+    assert (
+        blueprints.fetch_city_data("skopje", {"sensorId": "1000"})
+        is BatchOutcome.FAILED
+    )

--- a/tests/test_normalize_data.py
+++ b/tests/test_normalize_data.py
@@ -13,6 +13,7 @@ import pytest
 # Import the config package first so the api/preparation/processing chain initialises
 # in order — importing a ``processing`` submodule first hits a circular import.
 import api.config  # noqa: F401
+from utils import BatchOutcome
 from processing.normalize_data import (
     closest_hour,
     current_hour,
@@ -67,3 +68,58 @@ def test_current_hour_is_truncated_to_the_hour():
     assert now_hour.minute == 0
     assert now_hour.second == 0
     assert now_hour.microsecond == 0
+
+
+# --- process_data's outcome, which is what the fetch_hourly_data tally counts ---------
+
+
+_RAW_WEATHER = (
+    "time,temperature,humidity,pressure\n"
+    "1767225600,7.5,60.0,1013.0\n"
+    "1767229200,8.1,58.0,1012.0\n"
+    "1767232800,9.4,55.0,1011.0\n"
+)
+
+
+@pytest.fixture
+def data_paths(monkeypatch, tmp_path):
+    from processing import normalize_data
+
+    raw, processed = tmp_path / "raw", tmp_path / "processed"
+    (raw / "skopje" / "1000").mkdir(parents=True)
+    (processed / "skopje" / "1000").mkdir(parents=True)
+    monkeypatch.setattr(normalize_data, "DATA_RAW_PATH", raw)
+    monkeypatch.setattr(normalize_data, "DATA_PROCESSED_PATH", processed)
+    return normalize_data, raw, processed
+
+
+def test_process_data_reports_done_when_it_writes_new_readings(data_paths):
+    normalize_data, raw, processed = data_paths
+    (raw / "skopje" / "1000" / "weather.csv").write_text(_RAW_WEATHER)
+
+    outcome = normalize_data.process_data("skopje", "1000", "weather")
+
+    assert outcome is BatchOutcome.DONE
+    assert (processed / "skopje" / "1000" / "weather.csv").exists()
+
+
+def test_process_data_reports_skipped_when_there_is_nothing_new(data_paths):
+    # Running twice over the same raw file is the realistic shape: the hourly job re-reads
+    # a file whose rows are already downstream. That is not a failure and it is not work
+    # either, and a tally that counted it as DONE would report a fully idle pipeline as a
+    # fully productive one.
+    normalize_data, raw, _ = data_paths
+    (raw / "skopje" / "1000" / "weather.csv").write_text(_RAW_WEATHER)
+
+    assert normalize_data.process_data("skopje", "1000", "weather") is BatchOutcome.DONE
+    assert (
+        normalize_data.process_data("skopje", "1000", "weather") is BatchOutcome.SKIPPED
+    )
+
+
+def test_process_data_reports_failed_when_the_raw_file_is_missing(data_paths):
+    normalize_data, _, _ = data_paths
+
+    assert (
+        normalize_data.process_data("skopje", "1000", "weather") is BatchOutcome.FAILED
+    )

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -138,3 +138,62 @@ def test_fetch_locations_keeps_stored_sensors_when_only_that_call_fails(
 
     assert loads((raw / "cities.json").read_text()) == [_CITY]
     assert loads((raw / "skopje" / "sensors.json").read_text()) == [_SENSOR]
+
+
+def test_fetch_locations_summarises_what_it_managed_to_save(
+    tmp_path, monkeypatch, caplog
+):
+    # The end-to-end half of the tally: not that BatchTally counts (test_batch_tally.py
+    # covers that) but that this job is actually wired to one, and that a run in which the
+    # repository rejected everything is reported as ERROR rather than passing in silence.
+    _stub_locations(
+        monkeypatch, tmp_path, countries=[_COUNTRY], cities=[_CITY], sensors=[_SENSOR]
+    )
+
+    def refuse(**kwargs):
+        raise RuntimeError("the database is gone")
+
+    monkeypatch.setattr(schedule.repository, "save", refuse, raising=False)
+
+    with caplog.at_level("INFO", logger=schedule.__name__):
+        fetch_locations()
+
+    summaries = {
+        record.message.split(":")[0]: record
+        for record in caplog.records
+        if record.name == schedule.__name__ and " -- " in record.message
+    }
+    # One per sub-batch: countries, cities and sensors fail for different reasons and are
+    # counted apart so the log says which upstream is broken.
+    assert set(summaries) == {
+        "fetch_locations (countries)",
+        "fetch_locations (cities)",
+        "fetch_locations (sensors)",
+    }
+    for name, record in summaries.items():
+        assert (
+            record.levelname == "ERROR"
+        ), f"{name} should escalate when all units fail"
+        assert "0 done, 1 failed" in record.message
+
+
+def test_fetch_locations_reports_a_clean_run_without_raising_the_level(
+    tmp_path, monkeypatch, caplog
+):
+    # The other direction, so the assertion above cannot be satisfied by a tally that
+    # always says ERROR.
+    _stub_locations(
+        monkeypatch, tmp_path, countries=[_COUNTRY], cities=[_CITY], sensors=[_SENSOR]
+    )
+
+    with caplog.at_level("INFO", logger=schedule.__name__):
+        fetch_locations()
+
+    summaries = [
+        record
+        for record in caplog.records
+        if record.name == schedule.__name__ and " -- " in record.message
+    ]
+    assert len(summaries) == 3
+    assert all(record.levelname == "INFO" for record in summaries)
+    assert all("0 failed" in record.message for record in summaries)

--- a/tests/test_train_model.py
+++ b/tests/test_train_model.py
@@ -4,12 +4,14 @@ The training orchestration itself (hyper-parameter search, model persistence, pl
 is not exercised here — only the small, I/O-free frame transform it relies on.
 """
 
-from pandas import DataFrame
+import pytest
+from pandas import DataFrame, date_range
 
 # Import the config package first so the api/preparation/processing chain initialises
 # in order — importing a package submodule first can hit a circular import.
 import api.config  # noqa: F401
 from modeling.train_model import previous_value_overwrite
+from utils import BatchOutcome
 
 
 def test_previous_value_overwrite_shifts_up_and_drops_last_row():
@@ -19,3 +21,99 @@ def test_previous_value_overwrite_shifts_up_and_drops_last_row():
     result = previous_value_overwrite(dataframe)
     assert result.to_dict("list") == {"a": [2.0, 3.0], "b": [5.0, 6.0]}
     assert len(result.index) == 2
+
+
+# --- train_regression_model's outcome, which is what the model_training tally counts ---
+
+
+@pytest.fixture
+def training_stubs(monkeypatch, tmp_path):
+    """Neuter everything training does to disk, leaving only the outcome decision."""
+    from modeling import train_model
+
+    monkeypatch.setattr(train_model, "MODELS_PATH", tmp_path / "models")
+    monkeypatch.setattr(train_model, "DATA_PROCESSED_PATH", tmp_path / "processed")
+    monkeypatch.setattr(train_model, "check_best_regression_model", lambda path: False)
+    monkeypatch.setattr(train_model, "check_pollutant_lock", lambda path: False)
+    monkeypatch.setattr(train_model, "create_pollutant_lock", lambda path: None)
+    monkeypatch.setattr(train_model, "remove_pollutant_lock", lambda path: None)
+    monkeypatch.setattr(train_model, "draw_errors", lambda *args: None)
+    monkeypatch.setattr(train_model, "draw_predictions", lambda *args: None)
+    trained = []
+    monkeypatch.setattr(
+        train_model,
+        "generate_regression_model",
+        lambda frame, city, sensor, pollutant: trained.append(pollutant),
+    )
+    return train_model, trained
+
+
+_CITY = {"cityName": "skopje"}
+_SENSOR = {"sensorId": "1000"}
+
+
+def _frame_with(columns):
+    index = date_range("2026-01-01", periods=3, freq="1h")
+    return DataFrame({column: [1.0, 2.0, 3.0] for column in columns}, index=index)
+
+
+def test_train_regression_model_reports_done_when_it_trained(
+    training_stubs, monkeypatch
+):
+    train_model, trained = training_stubs
+    monkeypatch.setattr(
+        train_model, "fetch_summary_dataframe", lambda *a, **k: _frame_with(["pm2_5"])
+    )
+
+    outcome = train_model.train_regression_model(_CITY, _SENSOR, "pm2_5")
+
+    assert trained == ["pm2_5"]
+    assert outcome is BatchOutcome.DONE
+
+
+def test_train_regression_model_reports_skipped_when_the_sensor_lacks_the_pollutant(
+    training_stubs, monkeypatch
+):
+    # The distinction the model_training tally exists for. This path used to log
+    # "Completed training model" and return None, so a run in which not one sensor
+    # reported the pollutant was indistinguishable from a run that trained every model.
+    train_model, trained = training_stubs
+    monkeypatch.setattr(
+        train_model, "fetch_summary_dataframe", lambda *a, **k: _frame_with(["no2"])
+    )
+
+    outcome = train_model.train_regression_model(_CITY, _SENSOR, "pm2_5")
+
+    assert trained == [], "nothing should be trained without the pollutant column"
+    assert outcome is BatchOutcome.SKIPPED
+
+
+def test_train_regression_model_reports_skipped_when_a_model_already_exists(
+    training_stubs, monkeypatch
+):
+    train_model, _ = training_stubs
+    monkeypatch.setattr(train_model, "check_best_regression_model", lambda path: True)
+
+    assert (
+        train_model.train_regression_model(_CITY, _SENSOR, "pm2_5")
+        is BatchOutcome.SKIPPED
+    )
+
+
+def test_train_regression_model_reports_failed_when_training_raises(
+    training_stubs, monkeypatch
+):
+    train_model, _ = training_stubs
+    monkeypatch.setattr(
+        train_model, "fetch_summary_dataframe", lambda *a, **k: _frame_with(["pm2_5"])
+    )
+
+    def explode(*args):
+        raise RuntimeError("the model would not fit")
+
+    monkeypatch.setattr(train_model, "generate_regression_model", explode)
+
+    assert (
+        train_model.train_regression_model(_CITY, _SENSOR, "pm2_5")
+        is BatchOutcome.FAILED
+    )


### PR DESCRIPTION
Closes the gap raised and deliberately left open in #46: *"Nothing counts failures. A nightly run where every item failed and one where every item succeeded still exit the same way — the logs differ, and nothing else does."*

## The mechanism

`utils.BatchTally` wraps each batch loop. It counts attempted, failed and skipped units and emits one line when the loop ends, **escalating with the damage**:

| outcome | level |
| --- | --- |
| no units to process | `info` — a job with no work is not a broken job |
| all units done | `info` |
| some failed | `warning` |
| **every** unit failed | `error` — the job achieved nothing |

Getting the counts right and logging them all at `info` would have left things exactly as they were: a line nobody reads. The escalation is the feature, and it is what most of the tests assert.

**It is a context manager, not a self-summarising generator.** The loops here nest — city → sensor → collection — so `track()` on the innermost iterable is re-entered once per sensor. A generator that summarised on exhaustion would fire once per sensor rather than once per job. I wrote that version first and the nested `fetch_db_data` call site is what exposed it. `__exit__` fires exactly once however deep the nesting goes, *and* when the job raises partway through — "died after 12 of 400 sensors" is the most useful line in that log and the one an explicit call after the loop would lose.

Wired into seven batches across five scheduled jobs (`fetch_hourly_data`, `fetch_locations`, `import_data`, `model_training`, `predict_locations`) plus `fetch_db_data`. Sub-batches are counted separately where they fail for unrelated reasons — an upstream outage empties `fetch_hourly_data (fetch)` while a processing defect empties `fetch_hourly_data (process)`, and one combined number would hide which.

## Why the callees return an outcome instead of a bool

`fetch_city_data`, `process_data`, `train_regression_model` and `fetch_collection` isolate their own failures, so their caller could not tell what happened. They now return a `BatchOutcome` — `DONE`, `SKIPPED` or `FAILED`.

A `bool` will not do: **"nothing to do" and "it worked" are both truthy**, and conflating them is how a job that trained no models at all reports the same thing as one that trained every model it had. `train_regression_model` was in exactly that state — a sensor that never reported the pollutant fell through to logging `"Completed training model"`.

## The bug this exposed

While wiring the tally into `fetch_hourly_data`: **`fetch_city_data`'s API-lock guard has been inverted since `881ef2b` (2025-07-13 — 402 days).**

`check_api_lock()` is `not lock_file.exists()`, so **True means UNLOCKED**. The guard read:

```python
if check_api_lock():   # bails when the API is AVAILABLE
    return
```

which is the exact inverse of the one in its only caller — `fetch_hourly_data` bails on `not check_api_lock()`. So it returned immediately whenever OpenWeather was callable, and was only ever reached when the outer job had already bailed. **It fetched nothing under either condition**, and `reset_api_counter` clears the lock nightly, so the unlocked state is the normal one.

Nothing failed and nothing raised, which is why it survived 402 days. The tally is what makes it visible: every sensor skipped, every run. I have not verified the production data gap this implies — that needs a look at the actual `data/raw` timestamps on the server, which I can't reach.

## Verification

- **177 tests pass** (23 new across this PR), `black --check` and `ruff check` both exit 0, read directly rather than through a pipe.
- **Mutation-verified, six ways.** Restoring the inverted lock guard, removing the escalate-to-error branch, dropping the summary on abnormal exit, counting `SKIPPED` as done, and flipping either `train_regression_model`'s or `process_data`'s `SKIPPED` to `DONE` each kill a test.
- Two of those six **survived on the first attempt** — `train_regression_model` and `process_data` could each report `DONE` where they meant `SKIPPED` with nothing failing. That is the exact distinction the tally is built on, so the counting was resting on two untested decisions. The second commit closes both.

## Note

There is a pre-existing `--- Logging error ---` in local runs (a `cachelib` `PermissionError` clearing `/tmp/cache` from a teardown thread on Windows). I confirmed it reproduces on `master` with these changes stashed, so it is not from this work.
