### PR TITLE
refactor: name the API-lock predicate for its polarity

### DIFF
--- a/src/api/blueprints/__init__.py
+++ b/src/api/blueprints/__init__.py
@@ -7,7 +7,7 @@ from starlette.status import HTTP_404_NOT_FOUND
 
 from api.config.cache import cache
 from definitions import CACHE_TIMEOUTS, DATA_PROCESSED_PATH, DATA_RAW_PATH
-from preparation import check_api_lock, fetch_weather_data
+from preparation import api_is_available, fetch_weather_data
 from processing import read_csv_in_chunks
 from utils import BatchOutcome
 
@@ -54,13 +54,13 @@ def create_data_paths(city_name: str, sensor_id: str) -> None:
 
 
 def fetch_city_data(city_name: str, sensor: dict) -> BatchOutcome:
-    # `check_api_lock()` is `not lock_file.exists()`, so True means UNLOCKED -- the API is
-    # available and this should proceed. The guard was `if check_api_lock(): return`, the
-    # exact inverse of the one its only caller uses (`fetch_hourly_data` bails on `not
-    # check_api_lock()`), so this returned immediately whenever OpenWeather was callable
-    # and was only reached when the outer job had already bailed. It fetched nothing under
-    # either condition. Skipping is the LOCKED case, which is what this now says.
-    if not check_api_lock():
+    # This guard was `if check_api_lock(): return` for 402 days, which is the inverse of
+    # what it needed: that function returned `not lock_file.exists()`, so True meant the
+    # API was AVAILABLE and the early return fired exactly when there was work to do. The
+    # predicate is now named for its polarity, which is what stops the line being written
+    # backwards again -- `if not api_is_available()` cannot be misread the way
+    # `if check_api_lock()` could.
+    if not api_is_available():
         return BatchOutcome.SKIPPED
     create_data_paths(city_name, sensor["sensorId"])
     return (

--- a/src/api/config/schedule.py
+++ b/src/api/config/schedule.py
@@ -25,7 +25,7 @@ from definitions import (
 )
 from modeling import train_regression_model
 from preparation import (
-    check_api_lock,
+    api_is_available,
     fetch_cities,
     fetch_countries,
     fetch_sensors,
@@ -113,7 +113,7 @@ def dump_jobs() -> None:
 )
 @track_time
 def fetch_hourly_data() -> None:
-    if not check_api_lock():
+    if not api_is_available():
         logger.warning(
             "fetch_hourly_data: the OpenWeather API is locked; nothing fetched"
         )

--- a/src/preparation/__init__.py
+++ b/src/preparation/__init__.py
@@ -13,4 +13,4 @@ from .location_data import (
     read_sensors,
     recalculate_coordinate,
 )
-from .weather_data import check_api_lock, fetch_weather_data
+from .weather_data import api_is_available, fetch_weather_data

--- a/src/preparation/weather_data.py
+++ b/src/preparation/weather_data.py
@@ -18,7 +18,16 @@ from processing import flatten_json, save_dataframe
 logger = getLogger(__name__)
 
 
-def check_api_lock() -> bool:
+def api_is_available() -> bool:
+    """True when the OpenWeather quota lock is ABSENT, i.e. it is safe to call the API.
+
+    Named for the polarity rather than the mechanism. It was ``check_api_lock``, which
+    reads as "is it locked?" while returning the opposite -- and its two call sites were
+    written with opposite polarity as a result, one of them making the hourly fetch a
+    no-op for 402 days. The sibling ``check_pollutant_lock`` returns ``.exists()``, True
+    meaning LOCKED, so the two ``check_*_lock`` functions meant opposite things and the
+    correct call for one was the bug for the other.
+    """
     return not (DATA_PATH / f"{OPEN_WEATHER}.lock").exists()
 
 

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -204,18 +204,20 @@ def test_returns_an_empty_forecast_when_neither_source_has_one(
 def test_fetch_city_data_fetches_when_the_api_is_unlocked(monkeypatch, tmp_path):
     """The guard was inverted, so this never fetched anything.
 
-    ``check_api_lock()`` is ``not lock_file.exists()`` -- True means UNLOCKED. The guard
-    read ``if check_api_lock(): return``, the exact inverse of the one in its only caller
-    (``fetch_hourly_data`` bails on ``not check_api_lock()``). So it returned immediately
-    whenever OpenWeather was callable, and was only ever reached when the outer job had
-    already bailed: it fetched nothing under either condition.
+    The predicate is ``api_is_available()`` now; it was ``check_api_lock()``, which reads
+    as "is it locked?" while returning ``not lock_file.exists()`` -- the opposite. This
+    guard was written ``if check_api_lock(): return``, the exact inverse of the one in its
+    only caller (``fetch_hourly_data`` bailed on ``not check_api_lock()``), so it returned
+    immediately whenever OpenWeather was callable and was only ever reached when the outer
+    job had already bailed: it fetched nothing under either condition, for 402 days.
 
     Nothing failed and nothing raised, which is why it survived. The tally in
     ``fetch_hourly_data`` is what would have shown it -- every sensor skipped, every run.
+    The rename is what stops it recurring: ``if not api_is_available()`` cannot be misread.
     """
     monkeypatch.setattr(blueprints, "DATA_RAW_PATH", tmp_path / "raw")
     monkeypatch.setattr(blueprints, "DATA_PROCESSED_PATH", tmp_path / "processed")
-    monkeypatch.setattr(blueprints, "check_api_lock", lambda: True)  # unlocked
+    monkeypatch.setattr(blueprints, "api_is_available", lambda: True)  # unlocked
     calls = []
     monkeypatch.setattr(
         blueprints,
@@ -232,7 +234,7 @@ def test_fetch_city_data_fetches_when_the_api_is_unlocked(monkeypatch, tmp_path)
 def test_fetch_city_data_skips_when_the_api_is_locked(monkeypatch, tmp_path):
     monkeypatch.setattr(blueprints, "DATA_RAW_PATH", tmp_path / "raw")
     monkeypatch.setattr(blueprints, "DATA_PROCESSED_PATH", tmp_path / "processed")
-    monkeypatch.setattr(blueprints, "check_api_lock", lambda: False)  # locked
+    monkeypatch.setattr(blueprints, "api_is_available", lambda: False)  # locked
     calls = []
     monkeypatch.setattr(
         blueprints,
@@ -251,7 +253,7 @@ def test_fetch_city_data_skips_when_the_api_is_locked(monkeypatch, tmp_path):
 def test_fetch_city_data_reports_a_failed_fetch(monkeypatch, tmp_path):
     monkeypatch.setattr(blueprints, "DATA_RAW_PATH", tmp_path / "raw")
     monkeypatch.setattr(blueprints, "DATA_PROCESSED_PATH", tmp_path / "processed")
-    monkeypatch.setattr(blueprints, "check_api_lock", lambda: True)
+    monkeypatch.setattr(blueprints, "api_is_available", lambda: True)
     monkeypatch.setattr(blueprints, "fetch_weather_data", lambda *args: False)
 
     assert (


### PR DESCRIPTION
Follow-up to #47, which fixed the inverted call site but left the trap that produced it.

`check_api_lock()` returned `not lock_file.exists()` — True meant the API was **available** — while the name reads as "is it locked?". Its sibling in the same codebase is the opposite:

```python
def check_pollutant_lock(data_path) -> bool:
    return (MODELS_PATH / data_path / LOCK_FILE).exists()      # True = LOCKED
def check_api_lock() -> bool:
    return not (DATA_PATH / f"{OPEN_WEATHER}.lock").exists()   # True = NOT LOCKED
```

Same prefix, same noun, same file-existence mechanism, inverted meaning. `check_pollutant_lock` is used as `if … or check_pollutant_lock(…): return` — skip when locked — so **the correct call for one was the bug for the other**, which is exactly how `fetch_city_data` came to guard on `if check_api_lock(): return` and fetch nothing for 402 days.

Renamed to `api_is_available()`. `if not api_is_available()` cannot be read backwards; `if check_api_lock()` could. The docstring states the polarity and names the sibling it used to be confused with, so the next reader meets the hazard rather than rediscovering it.

Comments and test docstrings deliberately keep the old name where they describe the history — renaming those would make the record of the bug incomprehensible.

## Verification

Behaviour is unchanged. 177 tests pass, `black --check` and `ruff check` both rc=0, and the inversion mutant (`if api_is_available(): return`) still fails three tests — so the rename did not weaken the guard that catches this.

A fleet sweep for the same pattern across all 11 repos found no second instance in 52 bool-returning predicates. The detectors were validated against this repo at the pre-fix commit first. Notably `crypto-prophet`, which shares this repo's architecture, has `check_coin_lock()` returning `.exists()` — consistent with `check_pollutant_lock` — and no API-lock equivalent at all.
