### PR TITLE
ci(deploy): dump the dependency state when a deployment fails

### DIFF
--- a/.github/workflows/deploy_kubernetes_resources.sh
+++ b/.github/workflows/deploy_kubernetes_resources.sh
@@ -77,8 +77,55 @@ deploy_and_wait() {
     kubectl logs -n aqra -l "io.kompose.service=${name}" --tail=60 --all-containers || true
     echo "--- previous container logs (populated if it crash-looped) ---"
     kubectl logs -n aqra -l "io.kompose.service=${name}" --tail=60 --all-containers --previous || true
+    dump_dependency_state "${name}"
     return 1
   fi
+}
+
+# Everything about the namespace EXCEPT the deployment that failed.
+#
+# The 2026-08-18 deploys are why this exists. flask crash-looped on
+# `redis.exceptions.ConnectionError: Error 111 connecting to redis:6379. Connection
+# refused.` -- and the diagnostics above are all scoped to `-l io.kompose.service=flask`,
+# so the log said nothing whatsoever about redis: not its pod state, not its restart
+# count, not its events. The deploy reported redis "successfully rolled out" seconds
+# earlier in the same run, which is a contradiction the log had no way to explain.
+#
+# `get endpoints` is the decisive line and the reason this function is worth having: a
+# Service with no ready backends is exactly what produces ECONNREFUSED, and it is
+# invisible from the failing pod's own diagnostics. If redis shows `<none>` there, that is
+# the answer; if it lists an IP:6379, the fault is not endpoint readiness and the next
+# suspect is the redis process or the network path.
+dump_dependency_state() {
+  local failed=$1
+
+  echo "=============================================================="
+  echo "Namespace state (${failed} depends on these; a failure here is usually the cause)"
+  echo "=============================================================="
+
+  # Not `|| true` on its own: label every section so an EMPTY result is visibly empty
+  # rather than indistinguishable from a section that never ran.
+  echo "--- endpoints (a Service with no backends is what refuses connections) ---"
+  kubectl get endpoints -n aqra -o wide 2>&1 | sed 's/^/  /' || echo "  (could not read endpoints)"
+
+  echo "--- all pods in the namespace (restart counts are the tell) ---"
+  kubectl get pods -n aqra -o wide 2>&1 | sed 's/^/  /' || echo "  (could not read pods)"
+
+  echo "--- recent namespace events (OOMKilled and evictions land here) ---"
+  kubectl get events -n aqra --sort-by=.lastTimestamp 2>&1 | tail -25 | sed 's/^/  /' \
+    || echo "  (could not read events)"
+
+  for dependency in mongo redis; do
+    # An explicit `if`, not `[ ... ] && continue`: under `set -e` a false test makes the
+    # AND-list return non-zero as the last command in the loop body, which exits the whole
+    # deploy. The diagnostics must never be able to kill the run they are explaining.
+    if [ "${dependency}" = "${failed}" ]; then
+      continue
+    fi
+    echo "--- ${dependency} logs ---"
+    kubectl logs -n aqra -l "io.kompose.service=${dependency}" --tail=30 --all-containers 2>&1 \
+      | sed 's/^/  /' || echo "  (no ${dependency} logs)"
+  done
 }
 
 echo "Applying base resources..."


### PR DESCRIPTION
The deploy has been failing since 2026-08-18 22:14 and the log could not say why. This makes the next failure self-explaining.

## What the log could not tell us

flask crash-loops on:

```
redis.exceptions.ConnectionError: Error 111 connecting to redis:6379. Connection refused.
```

Every diagnostic in `deploy_and_wait`'s failure path is scoped to `-l io.kompose.service=${name}`. So when flask fails *because of* redis, the log contains nothing about redis — not its pod state, not its restart count, not its events, not its logs. Worse, the same run reported `deployment "redis" successfully rolled out` seconds earlier, and there was no way to reconcile that with a refused connection.

I spent a long investigation ruling things out that the log should simply have shown.

## What it prints now

`kubectl get endpoints` is the line that earns this — a Service with no ready backends is exactly what produces ECONNREFUSED, and it is invisible from the failing pod's own diagnostics:

```
--- endpoints (a Service with no backends is what refuses connections) ---
  NAME    ENDPOINTS           AGE
  flask   10.244.0.211:80     51d
  mongo   10.244.0.9:27017    51d
  redis   <none>              3d
--- all pods in the namespace (restart counts are the tell) ---
  redis-7c9d5f8b4-2xk9q   0/1     CrashLoopBackOff   88         3d
--- recent namespace events (OOMKilled and evictions land here) ---
--- mongo logs / redis logs ---
```

`redis <none>` would have been the whole answer, in one line.

## Two deliberate choices

**Every section is labelled and stderr is folded in**, rather than `|| true` per command. A section that returned nothing is then visibly empty instead of indistinguishable from one that never ran — which is the exact reason the original failure was hard to read.

**An explicit `if` rather than `[ x = y ] && continue`.** Under `set -e` a false test makes the AND-list the failing last command of the loop body and exits the whole deploy. Diagnostics must never kill the run they are explaining.

## Verification

The real function was **extracted from the shipped script and executed** — never a copy — against a stubbed `kubectl` reproducing the 2026-08-18 shape. It prints the output above. Two robustness cases were executed too:

- a `kubectl` that fails outright: still exits 0, errors shown as text
- the skip path (`failed=redis`): skips redis, keeps mongo, reaches the end without tripping `set -e`

`bash -n` and `shellcheck` are clean on the LF form (the only finding is a pre-existing SC2086 on line 85 at HEAD, untouched here). Local runs show SC1017 carriage-return errors, which are an artifact of `core.autocrlf` smudging — the file is committed `i/lf`, confirmed with `git ls-files --eol`.

## Scope

This does not fix the deploy; it makes the cause readable. The underlying coupling — `create_app()` → `init_data()` → `fetch_locations()` → `cache.set()` kills the process if redis is unreachable, so an optional cache is a hard startup dependency — is a separate decision, because `REDIS_URL` also backs the rate limiter and booting without it silently weakens brute-force protection on the auth endpoints.

Also worth noting separately: this repo has no `.gitattributes`, so shell scripts smudge to CRLF on Windows checkouts. A CRLF shebang would break these scripts on the server. Not changed here.
