### PR TITLE
ci: enforce LF for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Normalize line endings. The four shell scripts must stay LF: two of them are baked into
+# the image (docker/launch.sh is the container's entrypoint) and two run on the deploy
+# host over SSH. A CRLF `#!/bin/bash` makes Linux look for an interpreter literally named
+# "/bin/bash\r", which fails with exit 127 and an error naming a path that looks correct.
+#
+# Nothing here changes a committed file: every tracked file is already `i/lf`. This exists
+# to stop a Windows checkout introducing CRLF, which `core.autocrlf=true` makes easy to do
+# by accident. It also pins the WORKING tree to LF for *.sh, so shellcheck run locally
+# stops reporting SC1017 on every line and cascading into bogus parse errors around line
+# continuations -- an artifact that made a real deploy script look broken when it was not.
+* text=auto
+*.sh text eol=lf


### PR DESCRIPTION
This repo had no `.gitattributes`. With `core.autocrlf=true` a Windows checkout smudges every shell script to CRLF, and a commit from one could carry that back into the repo.

All four scripts here start `#!/bin/bash`. A CRLF shebang makes Linux look for an interpreter named literally `/bin/bash\r` — exit 127, with an error message naming a path that looks perfectly correct. Two of them are the container's own scripts (`docker/launch.sh` is the entrypoint) and two run on the deploy host over SSH, so the blast radius is the image and the deploy, not somebody's terminal.

Matches the convention already used by the seven fleet repos that have one.

## Nothing committed changes

All 176 tracked text files are already `i/lf`; the other 10 are empty. `git add --renormalize .` stages only this file:

```
$ git add --renormalize .
$ git diff --cached --name-only
.gitattributes
```

So this is protection against a future regression, not a repair.

One thing worth flagging about that check: `--renormalize` only re-adds *tracked* files, so my first run produced an empty diff simply because `.gitattributes` was still untracked — "nothing changed" and "nothing was staged" look identical. I re-ran it with the file staged before trusting the result.

## It also fixes a local-tooling lie

`shellcheck` against the smudged working tree reported **SC1017 on ~140 lines** and cascaded into bogus `SC1056`/`SC1072` parse errors around line continuations, which made a correct deploy script look broken. I chased exactly that while adding the deploy diagnostics in #49 and had to lint a `tr -d '\r'` copy to get an honest answer.

With the worktree pinned to LF:

```
SC1017 carriage-return errors now: 0
```

The only remaining finding is a pre-existing `SC2086` on line 132 (`kubectl apply -k ${KUBERNETES_DIR}` unquoted), which is present at HEAD and untouched here — happy to fix it separately.

## Verification

- `git ls-files --eol` moves all four scripts `w/crlf` → `w/lf`, with **0 CR bytes** on disk
- `bash -n` passes on each of the four
- black, ruff and **177 tests** all still green — changing `.gitattributes` changes what every tool sees, so the whole gate was re-run rather than just shellcheck

## Fleet note

The other three repos lacking a `.gitattributes` (`crypto-prophet`, `trading-bot`, `trencho`) ship **zero** shell scripts, so the gap is moot there. No rollout needed.
