### PR TITLE
fix(k8s): make both cronjobs actually run

### DIFF
--- a/kubernetes/cronjob/certificate-cronjob.yml
+++ b/kubernetes/cronjob/certificate-cronjob.yml
@@ -10,9 +10,14 @@ metadata:
   name: certificate-renewal
   namespace: aqra
 rules:
+  # `get` as well as `delete`. Verified against kubectl v1.36 rather than assumed:
+  # `kubectl delete secret <name> --ignore-not-found` issues a DELETE *and* a GET for the
+  # named resource, and `--ignore-not-found` only swallows a 404 -- a 403 from a missing
+  # `get` fails the job. The old script called `kubectl get` explicitly and this Role never
+  # granted it, which is why the job could never do anything (see the CronJob below).
   - apiGroups: [ "", "cert-manager.io" ]
     resources: [ "certificates", "secrets" ]
-    verbs: [ "delete" ]
+    verbs: [ "get", "delete" ]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -40,15 +45,30 @@ spec:
       template:
         spec:
           containers:
-            - command:
-                - /bin/sh
-                - -c
-                - |
-                  set -e
-                  kubectl get certificate aqra-tls -n aqra || exit 0
-                  kubectl get secret aqra-tls -n aqra || exit 0
-                  kubectl delete certificate aqra-tls -n aqra
-                  kubectl delete secret aqra-tls -n aqra
+            # This job has never renewed anything, for two independent reasons.
+            #
+            # 1. Its Role granted `delete` only, while the script's first line was
+            #    `kubectl get certificate ... || exit 0`. `get` was Forbidden, so the guard
+            #    always took the `exit 0` branch and the job reported Completed having
+            #    deleted nothing -- a silent no-op that looked healthy in every status
+            #    listing. The Role above now grants `get`.
+            #
+            # 2. #40 pinned registry.k8s.io/kubectl, which is DISTROLESS
+            #    (`Entrypoint: ["/bin/kubectl"]`, no Cmd, no /bin/sh), so since then the
+            #    container has died with `exec: "/bin/sh": ... no such file or directory`
+            #    before kubectl ran at all.
+            #
+            # `--ignore-not-found` replaces the get-guards outright: it is exactly what
+            # they were emulating, needs no extra permission beyond the `get` kubectl
+            # already performs, and deletes whichever of the two objects exists rather
+            # than skipping both when the first is absent.
+            - args:
+                - delete
+                - certificate/aqra-tls
+                - secret/aqra-tls
+                - -n
+                - aqra
+                - --ignore-not-found
               image: registry.k8s.io/kubectl:v1.36.3
               name: cronjob
           restartPolicy: OnFailure

--- a/kubernetes/cronjob/flask-cronjob.yml
+++ b/kubernetes/cronjob/flask-cronjob.yml
@@ -40,10 +40,21 @@ spec:
       template:
         spec:
           containers:
-            - command:
-                - /bin/sh
-                - -c
-                - set -e; kubectl rollout restart deployment flask -n aqra
+            # `args`, not `command`. This ran `/bin/sh -c "kubectl ..."` under
+            # bitnami/kubectl, which is Debian-based and has a shell. #40 pinned
+            # registry.k8s.io/kubectl instead, which is DISTROLESS -- its config is
+            # `Entrypoint: ["/bin/kubectl"]` with no Cmd and no /bin/sh -- so every run
+            # since has died before kubectl started, with
+            # `exec: "/bin/sh": stat /bin/sh: no such file or directory` and then
+            # BackoffLimitExceeded. The image's entrypoint IS kubectl, so the arguments
+            # go straight to it and no shell is involved.
+            - args:
+                - rollout
+                - restart
+                - deployment
+                - flask
+                - -n
+                - aqra
               image: registry.k8s.io/kubectl:v1.36.3
               name: kubectl
           restartPolicy: OnFailure


### PR DESCRIPTION
Found by #49's new deploy diagnostics, which dumped namespace events while investigating the deploy failure:

```
Warning  Failed  pod/flask-restart-29784960-4pkq5   Error: failed to create containerd task:
  ... exec: "/bin/sh": stat /bin/sh: no such file or directory: unknown
Warning  BackoffLimitExceeded  job/flask-restart-29784960   Job has reached the specified backoff limit
```

Neither cronjob has been doing its job, for two independent reasons — and one of them has **never worked at all**.

## 1. Both: distroless image, shell command

`flask-restart` and `certificate-renewal` both ran `command: [/bin/sh, -c, "kubectl ..."]`. That worked under `bitnami/kubectl:latest`, which is Debian-based. #40 pinned `registry.k8s.io/kubectl:v1.36.3` instead, which is **distroless**. Read from the registry rather than assumed:

```
Entrypoint: ['/bin/kubectl']
Cmd       : None
```

No `/bin/sh`. So every run since #40 has died before kubectl started. The image's entrypoint *is* kubectl, so the arguments belong in `args:` and no shell is involved.

## 2. `certificate-renewal`: a silent no-op since it was written

Its Role granted `verbs: ["delete"]`, while the script opened with:

```sh
kubectl get certificate aqra-tls -n aqra || exit 0
```

`get` was never granted, so that call was **Forbidden**, the guard always took the `exit 0` branch, and the job deleted nothing — while exiting 0 and reporting `Completed`. The diagnostics caught it looking perfectly healthy:

```
certificate-renewal-29759040-cd8t8   0/1   Completed   0   18d
```

A TLS renewal path that has been doing nothing, indistinguishable from one that worked. Same shape as the silent-`except` work earlier this week: a guard that turns the whole job into a healthy-looking no-op.

`--ignore-not-found` replaces the get-guards — it is exactly what they were emulating — and fixes a real edge they got wrong: the old script skipped the **secret** entirely whenever the certificate was absent, instead of deleting whichever exists.

## The Role change is verified, not assumed

I granted `get` alongside `delete` because `kubectl delete <name> --ignore-not-found` needs it. Rather than trusting my reading of kubectl's internals, I drove the local kubectl v1.36 against a stub API server and logged the requests:

```
requests kubectl made for the named resource:
   DELETE /api/v1/namespaces/aqra/secrets/aqra-tls
   GET    /api/v1/namespaces/aqra/secrets/aqra-tls
```

Both. And `--ignore-not-found` swallows a 404, not a 403 — so without `get` the job would fail Forbidden.

## Verification

`kubectl kustomize kubernetes` renders both CronJobs correctly:

```
CronJob certificate-renewal
   command : None
   args    : delete certificate/aqra-tls secret/aqra-tls -n aqra --ignore-not-found
CronJob flask-restart
   command : None
   args    : rollout restart deployment flask -n aqra
Role certificate-renewal: ['get', 'delete']
```

**Stated plainly:** a server-side dry-run was *not* possible. `kubectl apply --dry-run=client` still needs cluster discovery and there is no reachable cluster from here, so that check is unavailable rather than passing. The real proof will be the next scheduled run — `flask-restart` is nightly at 00:00, so it should show within a day.
