### PR TITLE
fix(k8s): probe redis over TCP and give it real memory headroom

### DIFF
--- a/kubernetes/deployment/redis-deployment.yml
+++ b/kubernetes/deployment/redis-deployment.yml
@@ -43,16 +43,31 @@ spec:
             - "allkeys-lru"
           ports:
             - containerPort: 6379
+          # tcpSocket, not `exec: [redis-cli, ping]`. kubelet dials the pod IP from OUTSIDE
+          # the container, which is what every client actually does; `redis-cli` with no
+          # -h connects to 127.0.0.1 INSIDE the pod, so it certified Redis as Ready without
+          # ever establishing that anything outside could reach it.
+          #
+          # Not theoretical. On 2026-08-19 restart #10 left a zombie container: containerd
+          # listed it Running while its OCI task was gone, so the pod sandbox still held
+          # the IP with nothing listening on 6379. The exec probe could not run at all --
+          # `cannot exec in a stopped container`, 1716 times over 3h39m -- and the pod
+          # stayed `Ready: True` throughout, so the Service kept the endpoint published and
+          # kube-proxy kept routing flask into a dead container. flask crash-looped for
+          # hours on `Error 111 connecting to redis:6379`, and three deploys timed out.
+          #
+          # A refused TCP connect is an ordinary probe failure, not a runtime error the
+          # kubelet cannot even start, so this fails cleanly where the exec could not.
           livenessProbe:
-            exec:
-              command: ["redis-cli", "ping"]
+            tcpSocket:
+              port: 6379
             initialDelaySeconds: 15
             periodSeconds: 30
             timeoutSeconds: 5
             failureThreshold: 3
           readinessProbe:
-            exec:
-              command: ["redis-cli", "ping"]
+            tcpSocket:
+              port: 6379
             initialDelaySeconds: 5
             periodSeconds: 10
             timeoutSeconds: 5
@@ -62,7 +77,18 @@ spec:
               cpu: "50m"
               memory: "64Mi"
             limits:
-              memory: "320Mi"
+              # 512Mi against `--maxmemory 256mb`. It was 320Mi, which is only 25% headroom,
+              # and Redis was OOMKilled (exit 137) ten times -- the last one 36 seconds after
+              # starting. `maxmemory` bounds the DATASET; process RSS additionally carries
+              # allocator fragmentation, replication/client output buffers and the odd large
+              # value, so the limit has to sit well above it rather than just above it.
+              #
+              # The dataset ceiling is deliberately left at 256mb: `allkeys-lru` evicts to
+              # stay under it, and this is a cache, so evicting is correct where being killed
+              # is not. Worth knowing if it recurs: `fetch_dataframe` is `@cache.memoize`d and
+              # stores whole pandas DataFrames, so a single large history frame can move a lot
+              # of bytes at once.
+              memory: "512Mi"
           volumeMounts:
             - mountPath: /data
               name: redis-data


### PR DESCRIPTION
Root cause of the three failed deploys, now confirmed on the cluster.

## What actually happened

```
Last State: Terminated   Reason: OOMKilled   Exit Code: 137
  Started: 23:02:27   Finished: 23:03:03        ← dead 36 seconds after starting
Restart Count: 10
Ready: True
Warning Unhealthy (x1716 over 3h39m)  Readiness probe errored: ... cannot exec in a stopped container
```

Redis was **OOMKilled ten times**. `--maxmemory 256mb` under `limits.memory: 320Mi` is only 25% headroom — and `maxmemory` bounds the *dataset*, while process RSS additionally carries allocator fragmentation and client output buffers.

Restart #10 then left a **zombie container**: `crictl` listed it `Running` while its OCI task was gone, so the pod sandbox still held `10.244.0.206` with nothing listening on 6379. Every connection got an instant RST — confirmed from inside the mongo pod, on both paths:

```
</dev/tcp/10.97.214.183/6379  → Connection refused    (ClusterIP)
</dev/tcp/10.244.0.206/6379   → Connection refused    (pod IP, bypasses kube-proxy)
```

That is the `redis.exceptions.ConnectionError: Error 111 ... Connection refused` that crash-looped flask for hours and timed out three deploys.

## Why nobody could see it — the part worth fixing

`exec: [redis-cli, ping]` with no `-h` connects to **127.0.0.1 inside the pod**. It can only ever certify that Redis is up from its own point of view, never that a client can reach it. And against a stopped container it cannot run *at all* — it errored 1716 times in 3h39m, and **the pod stayed `Ready: True` through every one of them**. So the Service kept the endpoint published and kube-proxy kept routing flask into a dead container, while `deploy_and_wait redis` cheerfully reported "successfully rolled out".

`tcpSocket` is dialled by kubelet **from outside the pod** — exactly what a client does. A refused connect is an ordinary probe failure rather than a runtime error the kubelet cannot even start, so it fails cleanly where the exec could not.

## Changes

- both probes `exec` → `tcpSocket: {port: 6379}`
- `limits.memory` 320Mi → **512Mi**
- `--maxmemory 256mb` **unchanged** — `allkeys-lru` evicting is correct for a cache; being OOMKilled is not

## Verification

Asserted on the rendered deployment: `tcpSocket` on both probes, against the port the container declares; `limits.memory: 512Mi`; `--maxmemory 256mb` untouched. The kustomize base still renders.

Worth recording: the deployments are applied **individually** by `deploy_and_wait` (`kubectl apply -f deployment/<name>-deployment.yml`), not through `kustomization.yml`, which lists only config-maps, cronjobs, ingress, issuers, PVs, sealed-secrets and services. I found that by asserting on the kustomize output and getting "redis Deployment not found in the render".

## Follow-up not included here

If Redis OOMs again at 512Mi, the next suspect is the app rather than the limit: `fetch_dataframe` is `@cache.memoize`d and stores whole pandas DataFrames in Redis, so one large history frame can move a lot of bytes at once. That would be a caching-strategy change, not a resource bump.
