### PR TITLE
ci(deploy): allow the deploy to be dispatched manually

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - master
+  # Redeploying after an infrastructure fix needed either a commit or
+  # `gh run rerun <id> --failed` -- the 2026-08-19 Redis outage was resolved on the node,
+  # and there was then no way to ask for a fresh deploy without pushing something. The
+  # rollout is idempotent (`kubectl apply` plus a rollout restart), so re-running it
+  # against an unchanged master is a no-op when nothing is wrong.
+  workflow_dispatch:
 
 env:
   OPENVPN_CONFIG: ${{ secrets.OPENVPN_CONFIG }}


### PR DESCRIPTION
The deploy triggered only on push to master. When the 2026-08-19 Redis outage was fixed **on the node**, there was no way to ask for a fresh deploy to confirm it — only pushing a commit, or `gh run rerun <id> --failed`.

```yaml
on:
  push:
    branches:
      - master
  workflow_dispatch:
```

Safe to expose for two reasons that already exist in this file:

- **The rollout is idempotent.** It is `kubectl apply` plus a rollout restart, so dispatching against an unchanged master is a no-op when nothing is wrong.
- **`concurrency: {group: deploy-production, cancel-in-progress: false}`** is a fixed group, so a dispatched run queues behind an in-flight push deploy instead of racing it on the same server directory — the race the concurrency block was added for in the first place.

Verified: the workflow parses and both triggers are present, with the push trigger unchanged (`branches: [master]`). Note for anyone asserting on this file in future — PyYAML parses the `on:` key as boolean `True`, not the string `"on"`.
