### PR TITLE
chore: consolidate the column-dtype TODOs and remove unused outlier functions

### DIFF
--- a/src/api/config/environment.py
+++ b/src/api/config/environment.py
@@ -65,11 +65,18 @@ def fetch_collection(collection: str, city_name: str, sensor_id: str) -> BatchOu
     try:
         dataframe = read_csv_in_chunks(collection_path)
         new_db_records = find_missing_data(db_records, dataframe, "time")
-        # TODO: Review this line for converting column data types
-        # new_db_records = new_db_records.astype(column_dtypes, errors="ignore")
-        # combined_df = concat([dataframe, new_db_records]).drop_duplicates(subset="time", keep="last")
-        # combined_df.to_csv(collection_path, index=False)
-        # del combined_df
+        # The column-dtype conversion is deliberately unfinished, and this is its one record.
+        #
+        # `processing.handle_data` already carries the pieces for it -- `store_dtypes` writes
+        # `{collection}_dtypes.json`, `find_dtypes` reads it back, `convert_dtype` renders a cell --
+        # and all three are covered by tests but called from nowhere, because the conversion was
+        # never wired up here. `convert_dtype`'s docstring points at this function by name.
+        #
+        # It used to be recorded as five byte-identical `# TODO: Review this line for converting
+        # column data types` comments beside five commented-out `astype(column_dtypes, ...)` calls,
+        # which read as five separate chores rather than the one unresolved question it is: should
+        # these frames be dtype-cast on write, and should the merge de-duplicate on `time`? The
+        # other four are gone; this is the one that stays, next to the code it would change.
         new_db_records.to_csv(collection_path, header=False, index=False, mode="a")
 
         save_dataframe(dataframe, collection, collection_path, sensor_id)
@@ -79,8 +86,6 @@ def fetch_collection(collection: str, city_name: str, sensor_id: str) -> BatchOu
         logger.exception(
             f"Could not fetch data from local storage for {city_name} - {sensor_id} - {collection}",
         )
-        # TODO: Review this line for converting column data types
-        # db_records = db_records.astype(column_dtypes, errors="ignore")
         # The records are still written, straight from the database rather than merged
         # with local storage, so this is a degraded write and not a lost one -- but it is
         # reported as FAILED because the merge it was asked to do did not happen.

--- a/src/api/config/git.py
+++ b/src/api/config/git.py
@@ -111,8 +111,6 @@ def merge_csv_files(repo: Repository, file_name: str, data: str) -> str | None:
             [local_file_content, repo_file_content], ignore_index=True
         )
         combined_content = trim_dataframe(combined_content, "time")
-        # TODO: Review this line for converting column data types
-        # combined_content = combined_content.astype(column_dtypes, errors="ignore")
         return combined_content.to_csv(index=False)
     except Exception:
         logger.exception(

--- a/src/processing/handle_data.py
+++ b/src/processing/handle_data.py
@@ -135,8 +135,6 @@ def save_dataframe(
             f"Could not fetch data from local storage for {sensor_id} - {collection}",
         )
     dataframe = dataframe.drop(columns="sensorId", errors="ignore")
-    # TODO: Review this line for converting column data types
-    # dataframe = dataframe.astype(column_dtypes, errors="ignore")
     dataframe.to_csv(
         collection_path, header=not collection_path.exists(), index=False, mode="a"
     )

--- a/src/processing/normalize_data.py
+++ b/src/processing/normalize_data.py
@@ -1,10 +1,8 @@
 from datetime import datetime, timedelta, tzinfo
 from logging import getLogger
 
-from numpy import abs
-from pandas import concat, DataFrame, Series, to_numeric
+from pandas import concat, Series, to_numeric
 from pytz import timezone
-from scipy.stats import zscore
 from sklearn.impute import KNNImputer
 
 from definitions import DATA_PROCESSED_PATH, DATA_RAW_PATH, POLLUTANTS
@@ -52,29 +50,6 @@ def current_hour(tz: tzinfo = None) -> datetime:
         )
 
     return current_datetime.replace(minute=0, second=0, microsecond=0)
-
-
-def drop_numerical_outliers_with_iqr_score(
-    dataframe: DataFrame, low: float = 0.05, high: float = 0.95
-) -> DataFrame:
-    df = dataframe.loc[:, dataframe.columns != "time"]
-    quant_df = df.quantile([low, high])
-    df = df.apply(
-        lambda x: x[(x > quant_df.loc[low, x.name]) & (x < quant_df.loc[high, x.name])],
-        axis=0,
-    )
-    df = concat([dataframe.loc[:, "time"], df], axis=1)
-    return df.dropna()
-
-
-def drop_numerical_outliers_with_z_score(
-    dataframe: DataFrame, z_thresh: int = 3
-) -> DataFrame:
-    df = dataframe.loc[:, dataframe.columns != "time"]
-    constrains = (abs(zscore(df)) < z_thresh).all(axis=1)
-    df = df.drop(index=df.index[~constrains])
-    df = concat([dataframe.loc[:, "time"], df], axis=1)
-    return df.dropna()
 
 
 def flatten_json(nested_json: dict, exclude=None) -> dict:
@@ -177,16 +152,12 @@ def process_data(city_name: str, sensor_id: str, collection: str) -> BatchOutcom
                 calculate_row_index, axis=1
             )
 
-        # dataframe_raw = drop_numerical_outliers_with_z_score(dataframe_raw)
-
         if dataframe_processed is not None:
             dataframe_raw = find_missing_data(
                 dataframe_raw, dataframe_processed, "time"
             )
 
         if len(dataframe_raw.index) > 0:
-            # TODO: Review this line for converting column data types
-            # dataframe_raw = dataframe_raw.astype(column_dtypes, errors="ignore")
             dataframe_raw.to_csv(
                 collection_path,
                 header=not collection_path.exists(),


### PR DESCRIPTION
Applies the comment finding from the 2026-08-19 `prune-comments` pass
(`.claude/workbench/reports/comment-hygiene-2026-08-19.md`) — and corrects it where the code
disagreed with the report.

Two labelled commits, both behaviour-preserving. **15 lines of comment removed, 26 lines of dead code
removed, 0 lines of live code touched.**

## 1. The five duplicated TODOs become one explained record

`# TODO: Review this line for converting column data types` appeared **five times, byte for byte**,
each beside a commented-out `astype(column_dtypes, ...)` call. Five copies read as five separate
chores rather than the one unresolved question they are, and none said what the question was.

**The audit said "delete these". Reading the code says otherwise, and the code is right.**
`processing/handle_data.py` carries the rest of the same unfinished feature — `store_dtypes` writes
`{collection}_dtypes.json`, `find_dtypes` reads it back, `convert_dtype` renders a cell — **all three
are covered by tests**, and `convert_dtype`'s docstring explicitly names
`api.config.environment.fetch_collection` as where the conversion belongs and says it is *"kept for
it"*.

Deleting all five would have orphaned that docstring's reference and left a tested,
deliberately-retained trio pointing at nothing. So: **one** record stays, next to the code it would
change, and it now explains the retention instead of merely marking it. The other four are gone.

## 2. The unused outlier functions go

`drop_numerical_outliers_with_iqr_score` and `drop_numerical_outliers_with_z_score` are two
implementations of the same idea, and **neither is called**. The only trace of either was a bare
commented-out call with no explanation.

Nothing defends these, which is what separates them from the cluster above: no docstring claims they
are kept for planned work, and **no test covers them**. `pyproject.toml` selects only `F401, F811` —
unused *imports* and redefinitions — so Ruff does not flag unused module-level functions, and this
has been invisible to every green CI run.

Removing them orphaned three imports (`numpy.abs`, `pandas.DataFrame`, `scipy.stats.zscore`) — which
Ruff **would** have caught — so those go too. `scipy` and `numpy` stay in `requirements/`; both are
still used by `feature_imputation.py` and others.

## What was deliberately left alone

- **The six `# TODO: Add additional assertions` in `tests/test_api.py`.** They mark status-code-only
  tests. Deleting them removes the only record that those assertions are thin — that is a
  `test-coverage` item, not a comment one.
- **`convert_dtype`, `find_dtypes`, `store_dtypes`** — documented, tested, deliberately retained.
- **The degraded-write explanation** in `fetch_collection`'s `except` branch, which was glued
  underneath one of the deleted TODOs and is a genuine *why* comment.

## Verification

Run against a scratch env, because this repo has no venv on this machine and only Python 3.13 is
installed (CI uses 3.14 — that is a separate recorded item):

- `black --check src tests definitions.py` — **rc=0**, 98 files unchanged
- `ruff check src tests definitions.py` — **rc=0**, all checks passed (this is what proves the
  orphaned imports were caught and cleared)
- every changed file compiles
- an AST pass confirms **zero** unused imports remain in `normalize_data.py`

`pytest` runs in CI, which has the right interpreter.