### PR TITLE
fix: run the application container as an unprivileged user

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -11,22 +11,6 @@ on:
   # against an unchanged master is a no-op when nothing is wrong.
   workflow_dispatch:
 
-env:
-  OPENVPN_CONFIG: ${{ secrets.OPENVPN_CONFIG }}
-  OPENVPN_USERNAME: ${{ secrets.OPENVPN_USERNAME }}
-  OPENVPN_PASSWORD: ${{ secrets.OPENVPN_PASSWORD }}
-  CA_CERT: ${{ secrets.CA_CERT }}
-  CLIENT_CERT: ${{ secrets.CLIENT_CERT }}
-  TLS_CRYPT_KEY: ${{ secrets.TLS_CRYPT_KEY }}
-  USER_KEY: ${{ secrets.USER_KEY }}
-  SSH_USERNAME: ${{ secrets.SSH_USERNAME }}
-  SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-  SERVER_HOST: ${{ secrets.SERVER_HOST }}
-  ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-  GIT_REPO_PATH: ${{ secrets.GIT_REPO_PATH }}
-  GIT_REPO_USERNAME: ${{ secrets.GIT_REPO_USERNAME }}
-  GIT_REPO_NAME: ${{ secrets.GIT_REPO_NAME }}
-
 permissions:
   contents: read
 
@@ -92,6 +76,33 @@ jobs:
     # Nothing is deployed unless an image was actually published.
     needs: build-and-push
     runs-on: ubuntu-latest
+
+    # Scoped to this job, not the workflow.
+    #
+    # These 14 are the production deploy credentials -- an SSH private key, the full OpenVPN
+    # credential set, and a repo access token. Declared at workflow level they were injected into
+    # the environment of every job, so `build-and-push` ran with all of them while needing only
+    # GITHUB_TOKEN for GHCR, alongside four third-party actions. Every consumer of every one of
+    # these is a step of this job.
+    #
+    # `test` was never exposed, but by accident rather than design: it is a reusable-workflow call
+    # (`uses: ./.github/workflows/test.yml`), and a called workflow does not inherit the caller's
+    # env.
+    env:
+      OPENVPN_CONFIG: ${{ secrets.OPENVPN_CONFIG }}
+      OPENVPN_USERNAME: ${{ secrets.OPENVPN_USERNAME }}
+      OPENVPN_PASSWORD: ${{ secrets.OPENVPN_PASSWORD }}
+      CA_CERT: ${{ secrets.CA_CERT }}
+      CLIENT_CERT: ${{ secrets.CLIENT_CERT }}
+      TLS_CRYPT_KEY: ${{ secrets.TLS_CRYPT_KEY }}
+      USER_KEY: ${{ secrets.USER_KEY }}
+      SSH_USERNAME: ${{ secrets.SSH_USERNAME }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      SERVER_HOST: ${{ secrets.SERVER_HOST }}
+      ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+      GIT_REPO_PATH: ${{ secrets.GIT_REPO_PATH }}
+      GIT_REPO_USERNAME: ${{ secrets.GIT_REPO_USERNAME }}
+      GIT_REPO_NAME: ${{ secrets.GIT_REPO_NAME }}
 
     steps:
       - name: Checkout

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -89,7 +89,29 @@ COPY . .
 # Copy the nginx configuration file.
 COPY ./docker/nginx.conf /etc/nginx/nginx.conf
 
-EXPOSE 80
+# Run unprivileged.
+#
+# Two daemons share this container: nginx (reverse proxy) and gunicorn (WSGI), started by
+# docker/launch.sh. Both had to be moved off root-owned paths for this to work:
+#   - nginx logs to stdout/stderr instead of /var/log/nginx, and its pid file moved to /tmp
+#   - gunicorn's pid file and the unix socket nginx proxies to moved from /run to /tmp
+#   - nginx's temp directories under /var/lib/nginx are chowned below; nginx creates files there
+#     for buffered request and proxy bodies, and the paths are compiled in rather than configured
+#
+# The listen port moved from 80 to 8080, because binding below 1024 needs CAP_NET_BIND_SERVICE.
+#
+# Application data is untouched by any of this: every write goes to $VOLUME_PATH (/var/api in the
+# cluster), which is a mounted volume. Its ownership is handled by the init container in
+# kubernetes/deployment/flask-deployment.yml, because kubelet does not apply fsGroup to a hostPath.
+RUN groupadd --system --gid 1001 app && \
+    useradd --system --uid 1001 --gid app --no-create-home --shell /usr/sbin/nologin app && \
+    mkdir -p /var/lib/nginx/body /var/lib/nginx/proxy /var/lib/nginx/fastcgi \
+             /var/lib/nginx/uwsgi /var/lib/nginx/scgi && \
+    chown -R app:app /var/lib/nginx
+
+EXPOSE 8080
+
+USER app
 
 # Run the application.
 ENTRYPOINT ["/bin/bash", "/app/docker/launch.sh"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -36,7 +36,8 @@ services:
     networks:
       - network
     ports:
-      - "80:80"
+      # Container listens on 8080 since it runs unprivileged; still published on 80 locally.
+      - "80:8080"
     volumes:
       - flask-data:/var/api
 

--- a/docker/gunicorn.conf.py
+++ b/docker/gunicorn.conf.py
@@ -6,8 +6,10 @@ disable_redirect_access_to_syslog = True
 
 preload_app = True
 chdir = "/app/src/api"
-pidfile = "/run/.pid"
-bind = ["unix:/run/gunicorn.socket"]
+# /run is root-owned and the process is unprivileged, so the pid file and the socket nginx proxies
+# to both live under /tmp. nginx's proxy_pass in docker/nginx.conf points at the same path.
+pidfile = "/tmp/gunicorn.pid"
+bind = ["unix:/tmp/gunicorn.socket"]
 workers = cpu_count() * 2 + 1
 threads = 4
 max_requests = 500

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,10 +1,11 @@
 # Define the number of worker processes; recommended value is the number of cores that are being used by your server
 worker_processes auto;
 
-# Define the location on the file system of the error log, plus the minimum severity to log messages for
-error_log /var/log/nginx/error.log warn;
-# Define the file that will store the process ID of the main NGINX process
-pid /var/run/nginx.pid;
+# Log to the container's stderr rather than a file. /var/log/nginx is root-owned, and the process is
+# unprivileged; sending it to stderr also puts nginx's errors where `kubectl logs` already looks.
+error_log /dev/stderr warn;
+# /var/run is root-owned, so the pid file moves somewhere the app user can write.
+pid /tmp/nginx.pid;
 
 # events block defines the parameters that affect connection processing.
 events {
@@ -34,7 +35,8 @@ http {
 #       default 0;
 #     }
     # Define the location of the log of access attempts to NGINX
-    access_log /var/log/nginx/access.log main;
+    # stdout for the same reason as error_log above.
+    access_log /dev/stdout main;
 #     TODO: Test this implementation
 #     access_log /var/log/nginx/access.log combined buffer=32k if=$loggable;
 
@@ -65,8 +67,11 @@ http {
 
     # Define the parameters for a specific virtual host/server
     server {
-        # Define the server name, IP address, and/or port of the server
-        listen 80;
+        # Define the server name, IP address, and/or port of the server.
+        # 8080, not 80: binding a port below 1024 needs CAP_NET_BIND_SERVICE, which the container
+        # no longer has now that it runs unprivileged. The Service still publishes 80 and maps to
+        # this, so nothing outside the pod changes.
+        listen 8080;
 
         # Define the specified charset to the "Content-Type" response header field
         charset utf-8;
@@ -87,7 +92,7 @@ http {
         # Define the location of the proxy server to send the request to
         location @app {
             include proxy_params;
-            proxy_pass http://unix:/run/gunicorn.socket;
+            proxy_pass http://unix:/tmp/gunicorn.socket;
         }
 
 #         location /images/ {

--- a/kubernetes/deployment/flask-deployment.yml
+++ b/kubernetes/deployment/flask-deployment.yml
@@ -24,6 +24,33 @@ spec:
         io.kompose.service: flask
     spec:
       automountServiceAccountToken: false
+      # kubelet applies fsGroup ownership to most volume types, but NOT to hostPath -- and
+      # flask-data-pvc is backed by one (/mnt/aqra/api on the node, see
+      # persistent-volume/flask-data-pv.yml). So a non-root app container would hit EACCES on its
+      # first write to /var/api, which is every write it makes.
+      #
+      # This runs as root, chowns the mount to the app uid, and exits. It is the standard fix for
+      # exactly this, and it needs no access to the node: the alternative was a manual
+      # `sudo chown` over SSH, which nothing in the repo could perform or re-assert.
+      #
+      # Idempotent, so it is safe on every rollout. It uses the app image rather than a second
+      # image so there is nothing extra to pull, and `chown -R` on an already-correct tree is
+      # cheap.
+      initContainers:
+        - name: fix-data-ownership
+          image: ghcr.io/trencho/air-quality-rest-api:latest
+          imagePullPolicy: Always
+          command: [ "chown", "-R", "1001:1001", "/var/api" ]
+          securityContext:
+            # runAsNonRoot must be overridden here, not just runAsUser. The pod-level block below
+            # applies to init containers too, and kubelet validates it: with runAsNonRoot inherited
+            # as true, a container asking for uid 0 is REFUSED at admission with
+            # "container has runAsNonRoot and image will run as root", and the pod never starts.
+            runAsNonRoot: false
+            runAsUser: 0
+          volumeMounts:
+            - mountPath: /var/api
+              name: flask-data
       containers:
         - envFrom:
             - configMapRef:
@@ -55,7 +82,7 @@ spec:
             failureThreshold: 90
             httpGet:
               path: /api/v1/healthz/live
-              port: 80
+              port: 8080
             periodSeconds: 10
           # Takes over only once startupProbe has succeeded, so no initialDelaySeconds
           # is needed here -- boot time is the startup probe's job, not liveness's.
@@ -63,7 +90,7 @@ spec:
             failureThreshold: 3
             httpGet:
               path: /api/v1/healthz/live
-              port: 80
+              port: 8080
             periodSeconds: 30
             timeoutSeconds: 10
           # periodSeconds was 300: a readiness check that missed its first attempt did
@@ -73,16 +100,25 @@ spec:
             failureThreshold: 3
             httpGet:
               path: /api/v1/healthz/ready
-              port: 80
+              port: 8080
             periodSeconds: 15
             timeoutSeconds: 10
           name: flask
           ports:
-            - containerPort: 80
+            # 8080, not 80: an unprivileged process cannot bind below 1024 without
+            # CAP_NET_BIND_SERVICE. The Service still publishes 80 and targets this.
+            - containerPort: 8080
           resources: { }
           volumeMounts:
             - mountPath: /var/api
               name: flask-data
+      # Same three keys mongo-deployment.yml and redis-deployment.yml already use. Those two set
+      # it and the application they exist for did not, which is what made this an oversight rather
+      # than a decision. uid 1001 matches the `app` user created in docker/Dockerfile.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
       volumes:
         - name: flask-data
           persistentVolumeClaim:

--- a/kubernetes/service/flask-service.yml
+++ b/kubernetes/service/flask-service.yml
@@ -9,6 +9,8 @@ spec:
   ports:
     - name: http
       port: 80
-      targetPort: 80
+      # The container listens on 8080 now (it runs unprivileged and cannot bind 80). The published
+      # port stays 80, so flask-ingress.yml and every client are unaffected.
+      targetPort: 8080
   selector:
     io.kompose.service: flask


### PR DESCRIPTION
Closes two Medium findings from the 2026-08-19 `security-audit` pass
(`.claude/workbench/reports/security-audit-2026-08-19.md`).

> **Held for you to merge.** This repo deploys on push to `master`, the pod is `strategy: Recreate`
> with `replicas: 1` — the old pod is killed *before* the new one starts, so there is no fallback if
> the rollout fails. Rollback: `kubectl rollout undo deployment/flask -n <ns>`. Worth having ready.

## 1. The app pod ran as root

`mongo-deployment.yml:65-68` and `redis-deployment.yml:95-98` already set
`runAsNonRoot`/`runAsUser`/`runAsGroup`. The pattern was known in this repo and applied to the two
datastores; only the application they exist for was missed. That is what made it an oversight rather
than a decision, and the new block uses the same three keys, in the same house style.

**This was not a two-line change.** Two daemons share this container — nginx and gunicorn, started by
`launch.sh` — so both had to move off root-owned paths:

| What | From | To |
|---|---|---|
| nginx error/access log | `/var/log/nginx/*` | stderr / stdout (also puts them where `kubectl logs` looks) |
| nginx pid | `/var/run/nginx.pid` | `/tmp/nginx.pid` |
| gunicorn pid + socket | `/run/.pid`, `/run/gunicorn.socket` | `/tmp/…` |
| nginx temp dirs | root-owned `/var/lib/nginx/*` | created and chowned at build time |
| listen port | 80 | **8080** — below 1024 needs `CAP_NET_BIND_SERVICE` |

The Service still publishes **80** and retargets 8080, so `flask-ingress.yml` and every client are
untouched.

### The hostPath problem, and why there is an init container

`flask-data-pvc` is backed by a **hostPath** (`/mnt/aqra/api`). kubelet applies `fsGroup` ownership to
most volume types but **not** to hostPath — so a non-root container hits `EACCES` on its first write
to `/var/api`, which is every write it makes.

A root init container chowns the mount and exits. It is idempotent, runs on every rollout, and needs
**no node access** — the alternative was a manual `sudo chown` over SSH that nothing in this repo
could perform or re-assert after a node rebuild.

It also carries `runAsNonRoot: false` explicitly. The pod-level block applies to init containers too,
and kubelet **validates** it: with `runAsNonRoot` inherited as true, a container asking for uid 0 is
refused at admission with *"container has runAsNonRoot and image will run as root"* and the pod never
starts. Found while checking the manifest, not in the cluster.

## 2. The 14 deployment secrets are scoped to the deploy job

They were at workflow level, so `build-and-push` ran with the production SSH private key and the full
OpenVPN credential set while needing only `GITHUB_TOKEN` for GHCR. Every consumer of every one of
them is a step of `deploy`. (`test` was never exposed, but by accident: it is a reusable-workflow
call, and a called workflow does not inherit the caller's `env`.)

## Verification — done locally, because a failed rollout here means downtime

| Check | Result |
|---|---|
| image builds | clean |
| effective user | `uid=1001(app) gid=1001(app)` |
| **nginx starts unprivileged** | yes — binds **8080**, pid written to `/tmp/nginx.pid` |
| nginx temp dirs writable | yes |
| **init-container chown proven end-to-end** | root chowns a volume → a later non-root container sees `app app` and writes successfully |
| permission errors in the app run | **0** |

And the controlled comparison, same image and env, only the uid differing:

```
non-root     uid=app    permErrors=0   lastLine=KeyError: 'MONGODB_CONNECTION'
forced root  uid=0:0    permErrors=0   lastLine=KeyError: 'MONGODB_CONNECTION'
```

Identical. The failure is the probe having no Mongo credentials, not the uid.

`kubectl apply --dry-run` was not available (the cluster is reachable only over VPN from Actions), so
manifests were validated by parsing and asserting the resulting structure — pod securityContext, init
container securityContext and command, container port, and all three probe ports.

## Deliberately not included

`readOnlyRootFilesystem`. It would break nginx's logs and pid, gunicorn's socket, the `/tmp/cache`
fallback and matplotlib's config dir. It needs emptyDir mounts at `/run`, `/var/log/nginx`,
`/var/lib/nginx` and `/tmp` — a separate change, and no manifest in this repo uses it today.