### PR TITLE
ci: bound the deploy job so a hung step cannot hold production for six hours

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -77,6 +77,19 @@ jobs:
     needs: build-and-push
     runs-on: ubuntu-latest
 
+    # A backstop against a hung runner, not a second deadline competing with the
+    # rollout budgets -- so it has to sit ABOVE them. deploy_kubernetes_resources.sh
+    # allows mongo 10m + redis 10m + flask 20m, and reload_pods.sh then waits on two
+    # more rollouts with no --timeout at all, so a slow-but-succeeding deploy can
+    # legitimately run for well over half an hour. A tighter value here would kill
+    # exactly the deploy it was meant to protect.
+    #
+    # Without this the default is 6 hours, and because this job holds the
+    # deploy-production concurrency group, a genuinely stuck step queues every later
+    # deploy behind it for that whole time. One did stall for 18 minutes on
+    # `Install OpenVPN` (normally ~10s) on 2026-08-19.
+    timeout-minutes: 60
+
     # Scoped to this job, not the workflow.
     #
     # These 14 are the production deploy credentials -- an SSH private key, the full OpenVPN


### PR DESCRIPTION
One line of YAML plus the reasoning for the number.

## The problem

`jobs.deploy` had no `timeout-minutes`, so GitHub's **360-minute** default applied. The job holds the `deploy-production` concurrency group, so a stuck step does not merely waste a runner — it queues every later deploy behind it for the rest of those six hours.

Not hypothetical. On 2026-08-19 a run sat **18 minutes on `Install OpenVPN`**, a step whose normal duration is about ten seconds, and I cancelled it by hand. The re-dispatch cleared that same step in 98 seconds, so the runner's network was degraded rather than dead — which is exactly the case a timeout handles better than a person watching the tab.

## Why 60 and not 30

This is a backstop against a hung runner, **not a second deadline competing with the rollout budgets**, so it has to sit above them:

| Wait | Budget |
|---|---|
| `deploy_and_wait mongo` | 10m |
| `deploy_and_wait redis` | 10m |
| `deploy_and_wait flask` | 20m |
| `reload_pods.sh` (mongo, flask) | **no `--timeout` at all** |

A slow-but-succeeding deploy can legitimately run past half an hour, so a tighter cap would kill precisely the deploy it exists to protect. 60 minutes still cuts the worst case from six hours to one.

## Scope

Only `deploy` is bounded. `test` and `build-and-push` neither hold the concurrency group nor touch production, so a hang there is ordinary CI noise rather than a production lock.

Worth knowing separately: `reload_pods.sh` is the one genuinely **unbounded** wait in the pipeline, and this job timeout is now the only thing that bounds it. Giving its two `kubectl rollout status` calls an explicit `--timeout` would be a better fix at that level — deliberately left out of a one-line safety change.

## Verification

YAML parses; `jobs.deploy.timeout-minutes = 60`, `needs` and all 6 steps unchanged.