### PR TITLE
ci: bound and retry the OpenVPN install so a stalled apt fails fast

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -144,9 +144,36 @@ jobs:
           echo "OpenVPN config found."
 
       - name: Install OpenVPN
+        # Required, not incidental: the connect action below installs nothing -- it writes
+        # the config and keys and runs `sudo openvpn` -- and openvpn is not on the runner
+        # image. These two lines come from that action's own README.
+        #
+        # They are also the most fragile step in the deploy. On 2026-08-19 this stalled at
+        # 18 minutes three times, against a normal duration of about ten seconds, and had
+        # to be cancelled by hand each time.
+        #
+        # Each apt call is bounded individually so a stall is KILLED and retried rather
+        # than hanging silently. `sudo timeout` rather than `timeout sudo`, so the signal
+        # reaches apt-get itself instead of the sudo wrapper it would otherwise stop at.
+        # timeout-minutes is only a backstop for the loop as a whole.
+        timeout-minutes: 10
         run: |
-          sudo apt update
-          sudo apt install -y openvpn openvpn-systemd-resolved
+          set -u
+          install_openvpn() {
+            sudo timeout 60 apt-get update -o Acquire::Retries=3 \
+              && sudo timeout 90 apt-get install -y -o Acquire::Retries=3 \
+                   openvpn openvpn-systemd-resolved
+          }
+          for attempt in 1 2 3; do
+            if install_openvpn; then
+              echo "OpenVPN installed on attempt ${attempt}: $(openvpn --version | head -1)"
+              exit 0
+            fi
+            echo "::warning::apt attempt ${attempt} did not finish within its budget; retrying"
+            sleep 10
+          done
+          echo "::error::could not install OpenVPN after 3 attempts"
+          exit 1
 
       - name: Create necessary OpenVPN key files
         run: |


### PR DESCRIPTION
Follow-up to the `timeout-minutes` PR. That one stopped a stall from holding production for six hours; this one stops the stall from costing eighteen minutes in the first place.

## The step that stalls

`Install OpenVPN` hung at **18 minutes three times on 2026-08-19**, against a normal duration of about ten seconds, and had to be cancelled by hand each time. It failed *silently* — apt printed nothing and the job simply sat there. Twice I could only tell it apart from a healthy deploy by noticing that steps 5–7 had recorded no `startedAt`.

## Deleting it was my first idea, and it was wrong

The connect action that follows **installs nothing**. `src/main.js` writes the config and key files, then:

```js
exec(`sudo openvpn --config ${configFile} --daemon --log openvpn.log --writepid openvpn.pid`);
```

It assumes the binary is present — and openvpn appears in the `Installed apt packages` table of **neither** the ubuntu-24.04 nor the ubuntu-22.04 runner image. These two lines are copied verbatim from that action's own README, where they are the documented prerequisite. Removing them would break the deploy outright.

## So the step stays, and fails fast instead

Each apt call gets its own budget, so a stall is **killed and retried** rather than hanging:

- **`sudo timeout` and not `timeout sudo`** — the signal has to reach `apt-get` itself rather than stopping at the sudo wrapper that spawned it.
- **Budgets of 60s and 90s**, which are 6–9× the observed normal duration.
- **`-o Acquire::Retries=3`** so apt retries transient network faults on its own before the outer loop has to.
- **`timeout-minutes: 10` on the step** as a backstop for the loop as a whole. The job-level timeout stays the outer bound.

## Driven, not just written

`apt-get` stubbed three ways, executing the real step body extracted from this file:

| Scenario | Result | Elapsed |
|---|---|---|
| clean install | exit 0 on attempt 1 | instant |
| first `update` stalls, then recovers | killed at 60s, retried, **exit 0 on attempt 2** | **71s** |
| every attempt fails | 3 warnings, `::error::`, exit 1 | 31s |

The middle row is the incident: **71 seconds where the real thing took 18 minutes.**

Also verified: the YAML parses, `bash -n` accepts the extracted `run:` body, and the sibling repo ships a byte-identical step.
