### PR TITLE
ci: stop transient failures from failing a deploy that already landed

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -168,8 +168,15 @@ jobs:
           fi
           echo "id=${ImageOS}-${ImageVersion}" >> "$GITHUB_OUTPUT"
 
+      # restore + save as SEPARATE steps, not `actions/cache`, and the save runs on
+      # `always()`. The combined action saves in a post step gated on `success()`, so a job
+      # that fails AFTER this install -- which is every failing deploy since 2026-08-19 --
+      # discards the .debs it just downloaded. The cache could then only ever appear on
+      # master once a master deploy had already succeeded, which is the thing it exists to
+      # protect. That circularity is why this cache had never served a single master run.
       - name: Restore the OpenVPN packages
-        uses: actions/cache@v6
+        id: aptcache
+        uses: actions/cache/restore@v6
         with:
           path: .aptcache
           key: apt-openvpn-${{ runner.os }}-${{ steps.runner_image.outputs.id }}
@@ -231,6 +238,15 @@ jobs:
           echo "${CLIENT_CERT}" | sudo tee /etc/openvpn/client.crt > /dev/null
           echo "${TLS_CRYPT_KEY}" | sudo tee /etc/openvpn/tls-crypt.key > /dev/null
 
+      # Save even when the deploy fails; skip it on a hit, because re-saving an unchanged
+      # entry under the same key is a no-op that only logs a warning.
+      - name: Save the OpenVPN packages
+        if: always() && steps.aptcache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: .aptcache
+          key: apt-openvpn-${{ runner.os }}-${{ steps.runner_image.outputs.id }}
+
       - name: Connect to VPN
         uses: kota65535/github-openvpn-connect-action@v3.1.0
         with:
@@ -240,13 +256,9 @@ jobs:
           password: ${{ env.OPENVPN_PASSWORD }}
           client_key: ${{ env.USER_KEY }}
 
-      - name: Record the deploy start time
-        id: deploy_started
-        run: echo "epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
-
       - name: SSH commands for checkout/update git repo, build and deploy
         id: remote_deploy
-        # Failure is handled below instead of here, so that a retry can be decided on.
+        # Failure is handled by the retry step below rather than failing the job here.
         continue-on-error: true
         uses: appleboy/ssh-action@v1.2.5
         with:
@@ -259,32 +271,33 @@ jobs:
           # mid-rollout and the deploy reports failure for a pod that was starting
           # normally.
           command_timeout: 25m
+          # Bounds the CONNECTION, not the command. Left unset, a dead peer burned
+          # 159s before reporting `handshake failed` on the sibling repo.
+          timeout: 30s
           # The script is a file so the retry below points at it rather than carrying a
           # second copy of it, and envs forwards the values it needs -- which also stops
           # five secrets being interpolated into the script text.
           envs: ACCESS_TOKEN,GIT_REPO_NAME,GIT_REPO_PATH,GIT_REPO_USERNAME,SSH_USERNAME
           script_path: .github/workflows/remote_deploy.sh
 
-      - name: Decide whether the failure is worth retrying
-        id: retry_decision
-        if: steps.remote_deploy.outcome == 'failure'
-        run: |
-          elapsed=$(( $(date +%s) - ${{ steps.deploy_started.outputs.epoch }} ))
-          # appleboy/ssh-action downloads its drone-ssh binary from a GitHub release at
-          # run time. When that download fails the step dies in about twenty seconds
-          # having never opened a session -- that happened on 2026-08-19 and is free to
-          # retry. A deploy that genuinely failed is minutes in, because it waits on
-          # `kubectl rollout status`; retrying that just runs a doomed deploy twice.
-          if [ "${elapsed}" -lt 120 ]; then
-            echo "retry=true" >> "$GITHUB_OUTPUT"
-            echo "::warning::remote deploy failed after ${elapsed}s -- too early to have reached the deploy itself, retrying once"
-          else
-            echo "retry=false" >> "$GITHUB_OUTPUT"
-            echo "::error::remote deploy failed after ${elapsed}s -- far enough in to be a real failure, not retrying"
-          fi
-
+      # Retry once on ANY failure, without asking how long the first attempt took.
+      #
+      # This used to gate on `elapsed < 120`, reasoning that anything further in must be a
+      # real failure not worth repeating. Both deploys in this fleet falsified that on
+      # 2026-08-19. Here the run took 324s: 64s to connect, 11s of git, 248s of `chown -R`,
+      # and under a second for the entire Kubernetes deploy -- so 313 of those 324 seconds
+      # were setup, and the gate declined a free retry while the clock was almost entirely
+      # measuring a recursive chown. On the sibling repo the SSH handshake HUNG for 159s
+      # and never opened a session at all. Elapsed time stood in for progress and measured
+      # neither.
+      #
+      # The asymmetry decides it: `remote_deploy.sh` is idempotent by construction -- the
+      # checkout is `git reset --hard`, the deploy is `kubectl apply` plus read-only waits
+      # -- so a wasted retry costs minutes, while a declined retry costs a red master and
+      # an undeployed production. Retry, and let the second attempt's own exit code fail
+      # the job if it fails too.
       - name: SSH commands for checkout/update git repo, build and deploy (retry)
-        if: steps.retry_decision.outputs.retry == 'true'
+        if: steps.remote_deploy.outcome == 'failure'
         uses: appleboy/ssh-action@v1.2.5
         with:
           host: ${{ env.SERVER_HOST }}
@@ -296,9 +309,9 @@ jobs:
           # mid-rollout and the deploy reports failure for a pod that was starting
           # normally.
           command_timeout: 25m
+          # Bounds the CONNECTION, not the command. Left unset, a dead peer burned
+          # 159s before reporting `handshake failed` on the sibling repo.
+          timeout: 30s
           envs: ACCESS_TOKEN,GIT_REPO_NAME,GIT_REPO_PATH,GIT_REPO_USERNAME,SSH_USERNAME
           script_path: .github/workflows/remote_deploy.sh
 
-      - name: Fail the job when the deploy failed and was not retried
-        if: steps.remote_deploy.outcome == 'failure' && steps.retry_decision.outputs.retry != 'true'
-        run: exit 1

--- a/.github/workflows/deploy_kubernetes_resources.sh
+++ b/.github/workflows/deploy_kubernetes_resources.sh
@@ -27,6 +27,26 @@ echo "Kubernetes API server reachable - proceeding with the deploy."
 #
 # So: wait for .status.observedGeneration to catch up to .metadata.generation first.
 # Only then does rollout status describe THIS rollout.
+
+# Read one jsonpath field off a deployment. Bounded (--request-timeout, three tries) and
+# DELIBERATELY NON-FATAL: it echoes the value, or nothing at all when the control plane
+# cannot be reached. Callers treat empty as "unknown", never as an error, because every
+# caller is a read that runs AFTER the change it is observing.
+kube_read() {
+  local name=$1 path=$2 attempt value
+  for attempt in 1 2 3; do
+    if value=$(kubectl get "deployment/${name}" -n aqra --request-timeout=15s \
+                 -o jsonpath="${path}" 2>/dev/null); then
+      printf '%s' "${value}"
+      return 0
+    fi
+    echo "kubectl get ${name} ${path} failed (attempt ${attempt}/3); retrying..." >&2
+    sleep 2
+  done
+  echo "kubectl get ${name} ${path} did not answer; continuing without it." >&2
+  return 0
+}
+
 deploy_and_wait() {
   local name=$1
   local timeout=${2:-10m}
@@ -55,15 +75,30 @@ deploy_and_wait() {
     kubectl rollout restart "deployment/${name}" -n aqra
   fi
 
+  # These two reads are READ-ONLY and must never fail the deploy, because by the time
+  # they run the mutation has already landed. On 2026-08-19 exactly that happened: the
+  # rollout restart was issued, this next line hit `net/http: TLS handshake timeout`, and
+  # `set -e` aborted the script -- reporting failure for a rollout that was already under
+  # way, on a run where every apply had reported `unchanged`.
+  #
+  # So they are bounded, retried, and non-fatal. `rollout status` below carries its own
+  # --timeout and is the real gate: an unreadable generation costs a slower path through
+  # it, never a red deploy.
   local generation observed
-  generation=$(kubectl get "deployment/${name}" -n aqra -o jsonpath='{.metadata.generation}')
-  for _ in $(seq 1 60); do
-    observed=$(kubectl get "deployment/${name}" -n aqra -o jsonpath='{.status.observedGeneration}')
-    if [ "${observed:-0}" -ge "${generation:-1}" ]; then
-      break
-    fi
-    sleep 1
-  done
+  generation=$(kube_read "${name}" '{.metadata.generation}')
+  if [ -n "${generation}" ]; then
+    for _ in $(seq 1 60); do
+      observed=$(kube_read "${name}" '{.status.observedGeneration}')
+      # An unreadable observedGeneration is not "behind" -- stop polling a control plane
+      # that is not answering and let rollout status make the call.
+      if [ -z "${observed}" ] || [ "${observed}" -ge "${generation}" ]; then
+        break
+      fi
+      sleep 1
+    done
+  else
+    echo "Could not read ${name}'s generation; skipping the observed-generation wait."
+  fi
 
   if ! kubectl rollout status "deployment/${name}" -n aqra --watch=true --timeout="${timeout}"; then
     echo "=============================================================="

--- a/.github/workflows/remote_deploy.sh
+++ b/.github/workflows/remote_deploy.sh
@@ -27,8 +27,17 @@ else
   git reset --hard origin/master
 fi
 
-echo "Setting correct ownership..."
-chown -R "${SSH_USERNAME}:${SSH_USERNAME}" "${GIT_REPO_PATH}"
+# Scoped to the checked-out tree, NOT to ${GIT_REPO_PATH}.
+#
+# This used to be `chown -R` over the whole repo path, which measured 248 seconds on
+# 2026-08-19 -- 76% of the entire SSH step, against under one second for the Kubernetes
+# deploy itself. The path also holds the server's generated `data/` tree, which this
+# deploy neither writes nor needs to own, and which is what makes the recursive walk
+# expensive. `git reset --hard` above already rewrote every tracked file as this user;
+# the only thing that then needs an ownership and mode fix is the workflow scripts about
+# to be executed.
+echo "Setting correct ownership on the workflow scripts..."
+chown -R "${SSH_USERNAME}:${SSH_USERNAME}" .github/workflows
 
 echo "Making scripts executable..."
 find .github/workflows -type f -name "*.sh" -exec chmod +x {} +


### PR DESCRIPTION
Master's deploy has been red since 2026-08-19 while production stayed healthy (HTTP 200 on real data). Four defects, all in the same direction: **the pipeline treats a recoverable blip as a permanent failure.**

## 1 · An unguarded read aborted the script *after* the mutation

`deploy_kubernetes_resources.sh:59` runs `generation=$(kubectl get deployment/flask ...)` immediately after `rollout restart`. Under `set -e` a failed command substitution aborts, so one `net/http: TLS handshake timeout` on a **read-only** call failed the deploy at 324s — on a run where every apply reported `unchanged` and mongo and redis had both rolled out.

Both reads now go through `kube_read`: `--request-timeout=15s`, three tries, and **deliberately non-fatal**. `rollout status` carries its own `--timeout` and is the real gate, so an unreadable generation costs a slower path, never a red deploy.

## 2 · The retry gate measured the clock, not progress

It declined a retry past 120s, reasoning anything that far in is a real failure. That run's 324s decomposes from the timestamped echoes:

| phase | seconds |
|---|---|
| drone-ssh connect | 64 |
| `git fetch` + `reset --hard` | 11 |
| **`chown -R`** | **248** |
| the entire Kubernetes deploy | <1 |

**313 of 324 seconds were setup.** The sibling repo's failure was a 159s hung SSH handshake that never opened a session — the opposite shape, same misreading.

`remote_deploy.sh` is idempotent by construction (its own header says so): `git reset --hard`, `kubectl apply`, read-only waits. So a wasted retry costs minutes and a declined one costs a red master. Retry on any failure; the second attempt's exit code decides.

## 3 · The apt cache could never populate on master

`actions/cache` saves in a post step gated on `success()`, so every failing deploy discarded the `.deb`s it had just downloaded. Combined with GitHub scoping caches to the branch that saved them, **this cache had never served a single master run** — it could only appear once a master deploy had already succeeded, which is the thing it exists to protect. Split into `cache/restore` + `cache/save` with `if: always()`.

## 4 · `chown -R` cost 248s of every deploy

76% of the SSH step, walking a server-generated `data/` tree this deploy neither writes nor owns. `git reset --hard` already rewrote every tracked file as this user; scoped to `.github/workflows`, the only thing that then needs a mode fix.

## Verification

Workflow parses; both shell scripts pass `bash -n`; no dangling references to the deleted `retry_decision`/`deploy_started` steps. **The real test is a green master run** — a workflow-only change takes effect from master regardless of what this PR shows, so re-dispatch after merge and read `.steps[].startedAt/completedAt`, which are accurate (the live step readout reports the *previous* step as in-progress).

Expect the first post-merge run to **miss** the apt cache: a PR-branch cache is not visible to master. The point of change 3 is that it will now save one.