### PR TITLE
docs: match the format command CI runs, and record the manual deploy route

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ on teardown). No network or MongoDB required.
 ## Formatting
 
 ```bash
-black .           # format
-black --check .   # verify (use before committing)
+black src tests definitions.py           # format
+black --check src tests definitions.py   # verify (this is what CI runs)
 ```
 
 ## Deployment
@@ -154,6 +154,9 @@ read containerd's, so the Deployment sat in `ErrImageNeverPull` and `/api/v1/*` 
 Before touching that pipeline:
 
 - **A merge to `master` dispatches a production deploy.** Know the cluster's state first.
+- **The deploy can also be dispatched by hand** from the Actions tab (`workflow_dispatch`). That is
+  the recovery path when a deploy failed for an infrastructure reason rather than a code one —
+  re-running it needs no commit.
 - **`.github/workflows/client.ovpn` must not be deleted.** Nothing in the tree references it —
   the `OPENVPN_CONFIG` secret holds its *path*. The workflow now fails fast and names the file
   if it goes missing, because the VPN action's own error masks the path as `***`.


### PR DESCRIPTION
Two small corrections.

**The format command.** The README gave `black .` while `test.yml` runs `black --check src tests definitions.py`. Following the README formats files CI never reads — and the two describe different scopes, so a green local run says less than it appears to.

**The manual deploy route.** `workflow_dispatch` was added in #53 and documented nowhere. It is the recovery path when a deploy fails for an infrastructure reason rather than a code one — which has happened four times in two days here — and re-running it needs no commit.
