### PR TITLE
chore: remove the DarkSky path, dead since Apple shut the service in 2023

### DIFF
--- a/definitions.py
+++ b/definitions.py
@@ -8,7 +8,6 @@ from pathlib import Path
 
 # Environment variable keys
 APP_ENV = "APP_ENV"
-DARK_SKY_TOKEN = "DARK_SKY_TOKEN"
 # When truthy, create_app() skips the upstream location fetch on startup so the app
 # can be imported without network access (the test suite sets it — see tests/conftest.py).
 SKIP_DATA_FETCH = "SKIP_DATA_FETCH"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,7 +15,6 @@ services:
       - .env
     environment:
       APP_ENV: ${APP_ENV:-}
-      DARK_SKY_TOKEN: ${DARK_SKY_TOKEN:-}
       ENABLED_COUNTRIES: ${ENABLED_COUNTRIES:-}
       GITHUB_TOKEN: ${GITHUB_TOKEN:-}
       MONGO_DATABASE: ${MONGO_DATABASE:-}

--- a/src/preparation/weather_data.py
+++ b/src/preparation/weather_data.py
@@ -7,7 +7,6 @@ from pandas import DataFrame, json_normalize
 from requests import get, RequestException
 
 from definitions import (
-    DARK_SKY_TOKEN,
     DATA_PATH,
     DATA_RAW_PATH,
     OPEN_WEATHER,
@@ -29,38 +28,6 @@ def api_is_available() -> bool:
     correct call for one was the bug for the other.
     """
     return not (DATA_PATH / f"{OPEN_WEATHER}.lock").exists()
-
-
-def fetch_dark_sky_data(city_name: str, sensor: dict) -> bool:
-    token = environ[DARK_SKY_TOKEN]
-    url = f"https://api.darksky.net/forecast/{token}/{sensor['position']}"
-    exclude = "currently,minutely,daily,alerts,flags"
-    extend = "hourly"
-    units = "si"
-    params = f"exclude={exclude}&extend={extend}&units={units}"
-
-    try:
-        weather_response = get(url, params)
-        hourly = weather_response.json()["hourly"]
-        dataframe = json_normalize(hourly["data"])
-
-        if len(dataframe.index) > 0:
-            save_dataframe(
-                dataframe,
-                "weather",
-                DATA_RAW_PATH / city_name / sensor["sensorId"] / "weather.csv",
-                sensor["sensorId"],
-            )
-        del dataframe
-        return True
-    except Exception:
-        logger.exception(
-            f"Error occurred while fetching DarkSky data for {city_name} - {sensor['sensorId']}",
-        )
-        return False
-    finally:
-        collect()
-        sleep(1)
 
 
 def fetch_open_weather_data(city_name: str, sensor: dict) -> bool:


### PR DESCRIPTION
`fetch_dark_sky_data` has **zero callers** — `grep -rn fetch_dark_sky_data` returns only its own definition — and it calls `api.darksky.net`, which **Apple retired at the end of March 2023**. It cannot have worked for over two years.

## It was not free to keep

- It dragged `DARK_SKY_TOKEN` through `definitions.py` and `docker-compose.yml`, so a dead token looked like live configuration.
- It was the only sibling still returning `bool` after #47 moved the others to `BatchOutcome`, which made the file read as though that migration were incomplete.
- **29 of `weather_data.py`'s 74 uncovered lines** were this function.

## Deliberately not removed: the sealed-secret entry

`kubernetes/sealed-secret/flask-sealed-secret.yml` still carries `DARK_SKY_TOKEN`.

Nothing consumes it by name — the deployment uses `envFrom: secretRef`, so every key becomes an env var and this one is now simply unused. Each `encryptedData` value is independently encrypted, so removing the line *should* be safe.

**"Should be" is the problem.** I cannot verify that against the cluster from here, and this repo's deploy went green two hours ago after two days red. The asymmetry is unattractive: a dead env var costs nothing, a broken sealed secret costs production. Left for the next secret rotation, when it can be re-sealed and observed.

Flagging it rather than silently skipping it — the finding is not fully closed.

## Verification

177 tests pass on the project venv; `black --check src tests definitions.py` clean. `collect` and `sleep` are still used elsewhere in the file, so those imports stay.
