### PR TITLE
test: assert the route bodies, not just the status code

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,9 +11,47 @@ class TestAPI(TestCase):
         app.config["TESTING"] = True
         return app
 
+    # The seeded processed frame (tests/conftest.py) holds a single row at
+    # 1704067200. The history endpoints default to the last seven days, so that row is
+    # never in range and `data` comes back empty -- which is why asserting the status
+    # alone said nothing about the data path. This pins the envelope; the test below
+    # asks for the window the seed is actually in and pins the row itself.
+    SEEDED_TIME = 1704067200
+    SENSOR_POSITION = (41.99249998, 21.423611)
+
+    def _assert_history_payload(self, response):
+        payload = loads(response.data)
+        self.assertIsInstance(payload, dict)
+        self.assertIn("data", payload)
+        self.assertIsInstance(payload["data"], list)
+        # Echoed back the right way round: a swapped pair is a classic defect here and
+        # the status code cannot see it.
+        latitude, longitude = self.SENSOR_POSITION
+        self.assertAlmostEqual(latitude, payload["latitude"])
+        self.assertAlmostEqual(longitude, payload["longitude"])
+
+    def _assert_pollutants_payload(self, response):
+        # The list is derived from the columns of the seeded pollution frame, so
+        # asserting its contents is what proves the endpoint read the data at all.
+        pollutants = loads(response.data)
+        self.assertIsInstance(pollutants, list)
+        self.assertEqual(
+            ["co", "no2", "o3", "pm10", "pm2_5", "so2"],
+            sorted(pollutant["value"] for pollutant in pollutants),
+        )
+        for pollutant in pollutants:
+            self.assertTrue(pollutant["name"])
+
     def test_get_cities(self):
         response = self.client.get(url_for("cities.cities"))
         self.assertEqual(response.status_code, 200)
+        # A 200 carrying a malformed or empty list used to pass here. The seeded
+        # fixture is skopje/MK, so the collection is pinned by content, not only shape.
+        cities = loads(response.data)
+        self.assertIsInstance(cities, list)
+        self.assertTrue(cities)
+        self.assertIn("skopje", [city["cityName"] for city in cities])
+        self.assertEqual("MK", cities[0]["countryCode"])
 
     def test_get_city(self):
         city_name = "skopje"
@@ -24,6 +62,10 @@ class TestAPI(TestCase):
     def test_get_countries(self):
         response = self.client.get(url_for("countries.countries"))
         self.assertEqual(response.status_code, 200)
+        countries = loads(response.data)
+        self.assertIsInstance(countries, list)
+        self.assertTrue(countries)
+        self.assertIn("MK", [country["countryCode"] for country in countries])
 
     def test_get_country(self):
         country_code = "MK"
@@ -46,7 +88,7 @@ class TestAPI(TestCase):
             )
         )
         self.assertEqual(response.status_code, 200)
-        # TODO: Add additional assertions for the received data
+        self._assert_history_payload(response)
         data_type = "pollution"
         response = self.client.get(
             url_for(
@@ -57,7 +99,7 @@ class TestAPI(TestCase):
             )
         )
         self.assertEqual(response.status_code, 200)
-        # TODO: Add additional assertions for the received data
+        self._assert_history_payload(response)
 
     def test_get_coordinates_history(self):
         latitude = 41.99249998
@@ -72,7 +114,7 @@ class TestAPI(TestCase):
             )
         )
         self.assertEqual(response.status_code, 200)
-        # TODO: Add additional assertions for the received data
+        self._assert_history_payload(response)
         data_type = "pollution"
         response = self.client.get(
             url_for(
@@ -83,7 +125,7 @@ class TestAPI(TestCase):
             )
         )
         self.assertEqual(response.status_code, 200)
-        # TODO: Add additional assertions for the received data
+        self._assert_history_payload(response)
 
     def test_get_city_sensor_pollutants(self):
         city_name = "skopje"
@@ -92,7 +134,7 @@ class TestAPI(TestCase):
             url_for("pollutants.city_sensor", city_name=city_name, sensor_id=sensor_id)
         )
         self.assertEqual(response.status_code, 200)
-        # TODO: Add additional assertions for the received data
+        self._assert_pollutants_payload(response)
 
     def test_get_coordinates_pollutants(self):
         latitude = 41.99249998
@@ -101,7 +143,33 @@ class TestAPI(TestCase):
             url_for("pollutants.coordinates", latitude=latitude, longitude=longitude)
         )
         self.assertEqual(response.status_code, 200)
-        # TODO: Add additional assertions for the received data
+        self._assert_pollutants_payload(response)
+
+    def test_get_city_sensor_history_returns_the_seeded_rows(self):
+        # Every other history test uses the default window -- the last seven days --
+        # which the seeded row (2024-01-01) is not in, so they all assert 200 over an
+        # empty `data`. Asking for the window the seed IS in is what exercises the read
+        # path: a history endpoint that returned nothing, or dropped a column, or served
+        # another sensor's frame, is invisible to the other tests and fails here.
+        response = self.client.get(
+            url_for(
+                "history.city_sensor",
+                city_name="skopje",
+                sensor_id="1000",
+                data_type="weather",
+                start_time=self.SEEDED_TIME - 3600,
+                end_time=self.SEEDED_TIME + 3600,
+            )
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = loads(response.data)
+        self.assertEqual(1, len(payload["data"]))
+        row = payload["data"][0]
+        self.assertEqual(self.SEEDED_TIME, row["time"])
+        self.assertAlmostEqual(7.5, row["temperature"])
+        self.assertAlmostEqual(60.0, row["humidity"])
+        self.assertAlmostEqual(1013.0, row["pressure"])
 
     def test_get_city_sensors(self):
         city_name = "skopje"


### PR DESCRIPTION
Acts on the observation in `test-validation-2026-08-20.md` - several route tests assert only `status_code == 200` - and runs the mutation probe that report deferred.

**177 -> 178 tests**, 0 skipped. `black --check` and `ruff check` both rc=0.

### Following the TODO found what the status codes were hiding

Six assertion sites carried a literal `# TODO: Add additional assertions for the received data`. Chasing them turned up something bigger:

`tests/conftest.py` seeds a processed frame with one row at `1704067200` (2024-01-01), commenting *"One row is enough - the tests assert 200."* The history endpoints default to a window of **the last seven days**, so that row is never in range. Every history test was asserting 200 over:

```json
{"data": [], "latitude": 41.99249998, "longitude": 21.423611}
```

The seeding worked, the endpoint was never asked for the data, and nothing said so.

### What changed

1. `/cities` and `/countries` pin the seeded skopje/MK content, not just a 200.
2. `_assert_history_payload` replaces the six TODOs: envelope shape plus `latitude`/`longitude` asserted the right way round - a swapped pair is a classic defect a status code cannot see.
3. `_assert_pollutants_payload` pins the pollutant list against the seeded frame's columns. That list is *derived* from the data, so asserting it proves the endpoint read the frame.
4. `test_get_city_sensor_history_returns_the_seeded_rows` passes an explicit window around the seed and asserts the row - time, temperature, humidity, pressure. It is the only test in the suite that reads a history row.

No fixture changed: the endpoint accepts `start_time`/`end_time`, so asking for the right window was enough, and it covers the query-parameter path as a side effect.

### Mutation log

| # | Mutation | Result |
|---|---|---|
| Q1 | `calculate_aqi` returns `min` instead of `max` | killed |
| Q2 | `to_aqi` drops the `+ i_low` offset | killed (3 tests) |
| Q3 | `calculate_index` selects the breakpoint with `>=` | killed (3 tests) |
| Q4 | history ignores the requested window | **killed by exactly one test - the new one** |

Q1-Q3 confirm the numeric core is genuinely defended. Q4 is the finding made concrete: 177 of 178 pass with the history window broken, and before this change it would have been 177 of 177.

https://claude.ai/code/session_01PGKAf76eTKBQYKiecbUff1
