### PR TITLE
chore: drop starlette for http.HTTPStatus, and gate import order

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,10 @@
 target-version = "py314"
 
 [tool.ruff.lint]
-# F401 = unused imports, F811 = redefinition/shadowing.
-select = ["F401", "F811"]
+# F401 = unused imports, F811 = redefinition/shadowing, I = import ordering.
+# `I` was missing: unused imports were gated and their ORDER was not, so a hand-added import
+# in the wrong block passed CI and only showed up as diff noise in the next person's commit.
+select = ["F401", "F811", "I"]
 
 [tool.ruff.lint.per-file-ignores]
 # Package __init__.py files intentionally re-export their public API; those imports are not "unused".

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -22,7 +22,6 @@ scikit-learn==1.9.0
 scipy==1.18.0
 SQLAlchemy==2.0.52
 seaborn==0.13.2
-starlette==1.6.0
 statsmodels==0.14.6
 urllib3==2.7.0
 waitress==3.0.2

--- a/requirements/dev.lock
+++ b/requirements/dev.lock
@@ -3,8 +3,6 @@
 #          versions (direct-only requirements make OSV guess oldest-compatible -> false positives).
 # Regenerate when the requirements change:  uv pip compile requirements/dev.txt -o requirements/dev.lock   (or pip-compile).
 #
-anyio==4.14.2
-    # via starlette
 apscheduler==3.11.3
     # via -r requirements/common.txt
 attrs==26.1.0
@@ -77,7 +75,6 @@ haversine==2.9.0
     # via -r requirements/common.txt
 idna==3.18
     # via
-    #   anyio
     #   requests
 iniconfig==2.3.0
     # via pytest
@@ -237,8 +234,6 @@ six==1.17.0
     #   flasgger
     #   python-dateutil
 sqlalchemy==2.0.52
-    # via -r requirements/common.txt
-starlette==1.6.0
     # via -r requirements/common.txt
 statsmodels==0.14.6
     # via -r requirements/common.txt

--- a/requirements/prod.lock
+++ b/requirements/prod.lock
@@ -3,8 +3,6 @@
 #          versions (direct-only requirements make OSV guess oldest-compatible -> false positives).
 # Regenerate when the requirements change:  uv pip compile requirements/prod.txt -o requirements/prod.lock   (or pip-compile).
 #
-anyio==4.14.2
-    # via starlette
 apscheduler==3.11.3
     # via -r requirements/common.txt
 attrs==26.1.0
@@ -66,7 +64,6 @@ haversine==2.9.0
     # via -r requirements/common.txt
 idna==3.18
     # via
-    #   anyio
     #   requests
 itsdangerous==2.2.0
     # via flask
@@ -186,8 +183,6 @@ six==1.17.0
     #   flasgger
     #   python-dateutil
 sqlalchemy==2.0.52
-    # via -r requirements/common.txt
-starlette==1.6.0
     # via -r requirements/common.txt
 statsmodels==0.14.6
     # via -r requirements/common.txt

--- a/src/api/blueprints/__init__.py
+++ b/src/api/blueprints/__init__.py
@@ -1,9 +1,9 @@
+from http import HTTPStatus
 from logging import getLogger
 from pathlib import Path
 
-from flask import jsonify, Response
+from flask import Response, jsonify
 from pandas import DataFrame
-from starlette.status import HTTP_404_NOT_FOUND
 
 from api.config.cache import cache
 from definitions import CACHE_TIMEOUTS, DATA_PROCESSED_PATH, DATA_RAW_PATH
@@ -44,7 +44,7 @@ def fetch_dataframe(
         jsonify(
             error_message="Cannot return historical data because the data is missing for that city and sensor."
         ),
-        HTTP_404_NOT_FOUND,
+        HTTPStatus.NOT_FOUND,
     )
 
 

--- a/src/api/blueprints/cities/cities.py
+++ b/src/api/blueprints/cities/cities.py
@@ -1,6 +1,7 @@
+from http import HTTPStatus
+
 from flasgger.utils import swag_from
-from flask import Blueprint, jsonify, Response
-from starlette.status import HTTP_404_NOT_FOUND
+from flask import Blueprint, Response, jsonify
 
 from api.config.cache import cache
 from definitions import CACHE_TIMEOUTS
@@ -23,7 +24,7 @@ def fetch_city(city_name: str = None) -> Response | tuple[Response, int]:
             jsonify(
                 error_message="Cannot return data because the city is not found or is invalid."
             ),
-            HTTP_404_NOT_FOUND,
+            HTTPStatus.NOT_FOUND,
         )
 
     return jsonify(city)

--- a/src/api/blueprints/countries/countries.py
+++ b/src/api/blueprints/countries/countries.py
@@ -1,6 +1,7 @@
+from http import HTTPStatus
+
 from flasgger.utils import swag_from
-from flask import Blueprint, jsonify, Response
-from starlette.status import HTTP_404_NOT_FOUND
+from flask import Blueprint, Response, jsonify
 
 from api.config.cache import cache
 from definitions import CACHE_TIMEOUTS
@@ -23,7 +24,7 @@ def fetch_country(country_code: str = None) -> Response | tuple[Response, int]:
             jsonify(
                 error_message="Cannot return data because the country is not found or is invalid."
             ),
-            HTTP_404_NOT_FOUND,
+            HTTPStatus.NOT_FOUND,
         )
 
     return jsonify(country)

--- a/src/api/blueprints/errors/errors.py
+++ b/src/api/blueprints/errors/errors.py
@@ -1,11 +1,7 @@
+from http import HTTPStatus
 from logging import getLogger
 
-from flask import Blueprint, jsonify, Response
-from starlette.status import (
-    HTTP_400_BAD_REQUEST,
-    HTTP_404_NOT_FOUND,
-    HTTP_500_INTERNAL_SERVER_ERROR,
-)
+from flask import Blueprint, Response, jsonify
 from werkzeug.exceptions import HTTPException
 from werkzeug.routing import ValidationError
 
@@ -18,22 +14,22 @@ logger = getLogger(__name__)
 def handle_validation_error(error) -> tuple[Response, int]:
     return (
         jsonify(error_message="Invalid parameter value", details=str(error)),
-        HTTP_400_BAD_REQUEST,
+        HTTPStatus.BAD_REQUEST,
     )
 
 
-@errors_blueprint.app_errorhandler(HTTP_404_NOT_FOUND)
+@errors_blueprint.app_errorhandler(HTTPStatus.NOT_FOUND)
 def handle_not_found_error(error) -> tuple[Response, int]:
     return (
         jsonify(
             error_message="Resource not found",
             details=getattr(error, "description", error.__class__.__name__),
         ),
-        HTTP_404_NOT_FOUND,
+        HTTPStatus.NOT_FOUND,
     )
 
 
-@errors_blueprint.app_errorhandler(HTTP_500_INTERNAL_SERVER_ERROR)
+@errors_blueprint.app_errorhandler(HTTPStatus.INTERNAL_SERVER_ERROR)
 def handle_unexpected_error(error) -> tuple[Response, int]:
     logger.exception(
         "Unexpected server error",
@@ -43,7 +39,7 @@ def handle_unexpected_error(error) -> tuple[Response, int]:
             error_message="Internal server error",
             details=getattr(error, "description", error.__class__.__name__),
         ),
-        HTTP_500_INTERNAL_SERVER_ERROR,
+        HTTPStatus.INTERNAL_SERVER_ERROR,
     )
 
 
@@ -63,5 +59,5 @@ def handle_generic_exception(error) -> tuple[Response, int]:
     )
     return (
         jsonify(error_message="Unhandled exception", details=str(error)),
-        HTTP_500_INTERNAL_SERVER_ERROR,
+        HTTPStatus.INTERNAL_SERVER_ERROR,
     )

--- a/src/api/blueprints/evaluation/evaluation.py
+++ b/src/api/blueprints/evaluation/evaluation.py
@@ -1,9 +1,9 @@
+from http import HTTPStatus
 from typing import Optional
 
 from flasgger import swag_from
-from flask import Blueprint, jsonify, Response
+from flask import Blueprint, Response, jsonify
 from pandas import isna, read_csv
-from starlette.status import HTTP_404_NOT_FOUND
 
 from api.config.cache import cache
 from api.config.converters import PollutantType
@@ -61,7 +61,7 @@ def fetch_sensor_evaluation(
             jsonify(
                 error_message="Cannot return forecast quality because the city is not found or is invalid."
             ),
-            HTTP_404_NOT_FOUND,
+            HTTPStatus.NOT_FOUND,
         )
 
     if check_sensor(city_name, sensor_id) is None:
@@ -69,7 +69,7 @@ def fetch_sensor_evaluation(
             jsonify(
                 error_message="Cannot return forecast quality because the sensor is not found or is invalid."
             ),
-            HTTP_404_NOT_FOUND,
+            HTTPStatus.NOT_FOUND,
         )
 
     results = {}
@@ -101,7 +101,7 @@ def fetch_pollutant_evaluation(
             jsonify(
                 error_message="Cannot return forecast quality because the city is not found or is invalid."
             ),
-            HTTP_404_NOT_FOUND,
+            HTTPStatus.NOT_FOUND,
         )
 
     if check_sensor(city_name, sensor_id) is None:
@@ -109,7 +109,7 @@ def fetch_pollutant_evaluation(
             jsonify(
                 error_message="Cannot return forecast quality because the sensor is not found or is invalid."
             ),
-            HTTP_404_NOT_FOUND,
+            HTTPStatus.NOT_FOUND,
         )
 
     if (
@@ -119,7 +119,7 @@ def fetch_pollutant_evaluation(
             jsonify(
                 error_message="Cannot return forecast quality because no trained model exists for that pollutant."
             ),
-            HTTP_404_NOT_FOUND,
+            HTTPStatus.NOT_FOUND,
         )
 
     return jsonify(evaluation)

--- a/src/api/blueprints/forecast/forecast.py
+++ b/src/api/blueprints/forecast/forecast.py
@@ -1,9 +1,9 @@
+from http import HTTPStatus
 from json import loads
 from logging import getLogger
 
 from flasgger import swag_from
-from flask import Blueprint, jsonify, Response
-from starlette.status import HTTP_404_NOT_FOUND
+from flask import Blueprint, Response, jsonify
 
 from api.config.cache import cache
 from api.config.repository import RepositorySingleton
@@ -34,7 +34,7 @@ def fetch_city_forecast(city_name: str) -> Response | tuple[Response, int]:
             jsonify(
                 error_message="Value cannot be predicted because the city is not found or is invalid."
             ),
-            HTTP_404_NOT_FOUND,
+            HTTPStatus.NOT_FOUND,
         )
 
     return jsonify(return_city_forecast_results(city))
@@ -58,7 +58,7 @@ def fetch_city_coordinates_forecast(
                 error_message="Value cannot be predicted because the coordinates are far away from all "
                 "available cities."
             ),
-            HTTP_404_NOT_FOUND,
+            HTTPStatus.NOT_FOUND,
         )
 
     forecast = return_city_forecast_results(city)
@@ -82,7 +82,7 @@ def fetch_sensor_forecast(
             jsonify(
                 error_message="Value cannot be predicted because the city is not found or is invalid."
             ),
-            HTTP_404_NOT_FOUND,
+            HTTPStatus.NOT_FOUND,
         )
 
     sensor = check_sensor(city_name, sensor_id)
@@ -91,7 +91,7 @@ def fetch_sensor_forecast(
             jsonify(
                 error_message="Value cannot be predicted because the sensor is not found or inactive."
             ),
-            HTTP_404_NOT_FOUND,
+            HTTPStatus.NOT_FOUND,
         )
 
     return jsonify(return_sensor_forecast_results(city, sensor))
@@ -115,7 +115,7 @@ def fetch_sensor_coordinates_forecast(
                 error_message="Value cannot be predicted because the coordinates are far away from all "
                 "available sensors."
             ),
-            HTTP_404_NOT_FOUND,
+            HTTPStatus.NOT_FOUND,
         )
 
     if (city := check_city(sensor["cityName"])) is not None:
@@ -127,7 +127,7 @@ def fetch_sensor_coordinates_forecast(
         jsonify(
             error_message="Value cannot be predicted because the sensor is not found or is invalid."
         ),
-        HTTP_404_NOT_FOUND,
+        HTTPStatus.NOT_FOUND,
     )
 
 

--- a/src/api/blueprints/history/history.py
+++ b/src/api/blueprints/history/history.py
@@ -1,11 +1,11 @@
 from datetime import datetime
+from http import HTTPStatus
 from json import loads
 from pathlib import Path
 
 from flasgger import swag_from
-from flask import Blueprint, jsonify, Response, request
+from flask import Blueprint, Response, jsonify, request
 from pandas import DataFrame
-from starlette.status import HTTP_400_BAD_REQUEST, HTTP_404_NOT_FOUND
 
 from api.blueprints import fetch_dataframe
 from api.config.cache import cache
@@ -31,7 +31,7 @@ def fetch_city_sensor_history(
             jsonify(
                 error_message="Cannot return historical data because the data type is not found or is invalid."
             ),
-            HTTP_404_NOT_FOUND,
+            HTTPStatus.NOT_FOUND,
         )
 
     timestamps = retrieve_history_timestamps()
@@ -44,7 +44,7 @@ def fetch_city_sensor_history(
             jsonify(
                 error_message="Cannot return historical data because the city is not found or is invalid."
             ),
-            HTTP_404_NOT_FOUND,
+            HTTPStatus.NOT_FOUND,
         )
 
     if (sensor := check_sensor(city_name, sensor_id)) is None:
@@ -52,7 +52,7 @@ def fetch_city_sensor_history(
             jsonify(
                 error_message="Cannot return historical data because the sensor is not found or is invalid."
             ),
-            HTTP_404_NOT_FOUND,
+            HTTPStatus.NOT_FOUND,
         )
 
     return return_historical_data(city_name, sensor, data_type, start_time, end_time)
@@ -71,7 +71,7 @@ def fetch_coordinates_history(
             jsonify(
                 error_message="Cannot return historical data because the data type is not found or is invalid."
             ),
-            HTTP_404_NOT_FOUND,
+            HTTPStatus.NOT_FOUND,
         )
 
     timestamps = retrieve_history_timestamps()
@@ -85,7 +85,7 @@ def fetch_coordinates_history(
                 error_message="Cannot return historical data because the coordinates are far away from all available "
                 "sensors."
             ),
-            HTTP_404_NOT_FOUND,
+            HTTPStatus.NOT_FOUND,
         )
 
     return return_historical_data(
@@ -106,12 +106,12 @@ def retrieve_history_timestamps() -> tuple[int, int] | tuple[Response, int]:
             jsonify(
                 error_message="Specify end timestamp larger than the current hour's timestamp."
             ),
-            HTTP_400_BAD_REQUEST,
+            HTTPStatus.BAD_REQUEST,
         )
     if end_time > start_time + week_in_seconds:
         return (
             jsonify(error_message="Specify start and end time in one week range."),
-            HTTP_400_BAD_REQUEST,
+            HTTPStatus.BAD_REQUEST,
         )
 
     return start_time, end_time

--- a/src/api/blueprints/plots/plots.py
+++ b/src/api/blueprints/plots/plots.py
@@ -1,6 +1,7 @@
+from http import HTTPStatus
+
 from flasgger import swag_from
-from flask import Blueprint, jsonify, Response, send_file
-from starlette.status import HTTP_404_NOT_FOUND
+from flask import Blueprint, Response, jsonify, send_file
 
 from api.config.converters import ErrorType, PollutantType
 from definitions import RESULTS_ERRORS_PLOTS_PATH, RESULTS_PREDICTIONS_PLOTS_PATH
@@ -23,7 +24,7 @@ def fetch_plots_predictions(
             jsonify(
                 error_message="Cannot return plot because the city is not found or is invalid."
             ),
-            HTTP_404_NOT_FOUND,
+            HTTPStatus.NOT_FOUND,
         )
 
     if check_sensor(city_name, sensor_id) is None:
@@ -31,7 +32,7 @@ def fetch_plots_predictions(
             jsonify(
                 error_message="Cannot return plot because the sensor is not found or is invalid."
             ),
-            HTTP_404_NOT_FOUND,
+            HTTPStatus.NOT_FOUND,
         )
 
     image_path = (
@@ -44,7 +45,7 @@ def fetch_plots_predictions(
     if not image_path.exists():
         return (
             jsonify(error_message="Cannot return plot because it does not exist."),
-            HTTP_404_NOT_FOUND,
+            HTTPStatus.NOT_FOUND,
         )
 
     return send_file(image_path, mimetype="image/png", max_age=3600)
@@ -64,7 +65,7 @@ def fetch_plots_errors(
             jsonify(
                 error_message="Cannot return plot because the city is not found or is invalid."
             ),
-            HTTP_404_NOT_FOUND,
+            HTTPStatus.NOT_FOUND,
         )
 
     if check_sensor(city_name, sensor_id) is None:
@@ -72,7 +73,7 @@ def fetch_plots_errors(
             jsonify(
                 error_message="Cannot return plot because the sensor is not found or is invalid."
             ),
-            HTTP_404_NOT_FOUND,
+            HTTPStatus.NOT_FOUND,
         )
 
     image_path = (
@@ -85,7 +86,7 @@ def fetch_plots_errors(
     if not image_path.exists():
         return (
             jsonify(error_message="Cannot return plot because it does not exist."),
-            HTTP_404_NOT_FOUND,
+            HTTPStatus.NOT_FOUND,
         )
 
     return send_file(image_path, mimetype="image/png", max_age=3600)

--- a/src/api/blueprints/pollutants/pollutants.py
+++ b/src/api/blueprints/pollutants/pollutants.py
@@ -1,9 +1,9 @@
+from http import HTTPStatus
 from pathlib import Path
 
 from flasgger import swag_from
-from flask import Blueprint, jsonify, Response
+from flask import Blueprint, Response, jsonify
 from pandas import DataFrame
-from starlette.status import HTTP_404_NOT_FOUND
 
 from api.blueprints import fetch_dataframe
 from api.config.cache import cache
@@ -48,7 +48,7 @@ def fetch_city_sensor_pollutants(
             jsonify(
                 error_message="Cannot return available pollutants because the city is not found or is invalid."
             ),
-            HTTP_404_NOT_FOUND,
+            HTTPStatus.NOT_FOUND,
         )
 
     if check_sensor(city_name, sensor_id) is None:
@@ -56,7 +56,7 @@ def fetch_city_sensor_pollutants(
             jsonify(
                 error_message="Cannot return available pollutants because the sensor is not found or is invalid."
             ),
-            HTTP_404_NOT_FOUND,
+            HTTPStatus.NOT_FOUND,
         )
 
     return fetch_measurements(city_name, sensor_id)
@@ -78,7 +78,7 @@ def fetch_coordinates_pollutants(
                 error_message="Cannot return available pollutants because the coordinates are far away from all available "
                 "sensors."
             ),
-            HTTP_404_NOT_FOUND,
+            HTTPStatus.NOT_FOUND,
         )
 
     return fetch_measurements(sensor["cityName"], sensor["sensorId"])

--- a/src/api/blueprints/sensors/sensors.py
+++ b/src/api/blueprints/sensors/sensors.py
@@ -1,6 +1,7 @@
+from http import HTTPStatus
+
 from flasgger import swag_from
-from flask import Blueprint, jsonify, Response
-from starlette.status import HTTP_404_NOT_FOUND
+from flask import Blueprint, Response, jsonify
 
 from api.config.cache import cache
 from definitions import CACHE_TIMEOUTS
@@ -24,7 +25,7 @@ def fetch_city_sensor(
             jsonify(
                 error_message="Cannot return data because the city is not found or is invalid."
             ),
-            HTTP_404_NOT_FOUND,
+            HTTPStatus.NOT_FOUND,
         )
 
     if sensor_id is None:
@@ -35,7 +36,7 @@ def fetch_city_sensor(
             jsonify(
                 error_message="Cannot return data because the sensor is not found or is invalid."
             ),
-            HTTP_404_NOT_FOUND,
+            HTTPStatus.NOT_FOUND,
         )
 
     return jsonify(sensor)

--- a/src/api/config/__init__.py
+++ b/src/api/config/__init__.py
@@ -2,12 +2,13 @@ from os import environ
 
 from flask import Flask
 
-from definitions import ENV_DEV, APP_ENV, ENV_PROD, SKIP_DATA_FETCH
+from definitions import APP_ENV, ENV_DEV, ENV_PROD, SKIP_DATA_FETCH
+
 from .blueprints import init_blueprints
 from .cache import init_cache
 from .converters import init_converters
 from .cors import init_cors
-from .environment import init_environment_variables, init_data, init_system_paths
+from .environment import init_data, init_environment_variables, init_system_paths
 from .garbage_collection import init_gc
 from .health import init_healthcheck
 from .limiter import init_limiter

--- a/src/api/config/dump.py
+++ b/src/api/config/dump.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from sqlite3 import connect, Cursor
+from sqlite3 import Cursor, connect
 from typing import Any
 
 

--- a/src/api/config/environment.py
+++ b/src/api/config/environment.py
@@ -18,6 +18,7 @@ from definitions import (
 from preparation import read_cities, read_sensors
 from processing import find_missing_data, read_csv_in_chunks, save_dataframe
 from utils import BatchOutcome, BatchTally
+
 from .repository import RepositorySingleton
 from .schedule import fetch_locations
 

--- a/src/api/config/health.py
+++ b/src/api/config/health.py
@@ -1,9 +1,10 @@
 from logging import getLogger
 
-from flask import Flask, jsonify, Response
+from flask import Flask, Response, jsonify
 from flask_healthz import Healthz
 
 from definitions import CACHE_TIMEOUTS, URL_PREFIX
+
 from .cache import cache
 
 logger = getLogger(__name__)

--- a/src/api/config/repository.py
+++ b/src/api/config/repository.py
@@ -8,14 +8,14 @@ from pymongo import ASCENDING, MongoClient
 
 from definitions import (
     APP_ENV,
+    COLLECTIONS,
     ENV_DEV,
     ENV_PROD,
-    COLLECTIONS,
-    MONGODB_CONNECTION,
     MONGO_DATABASE,
-    MONGODB_HOSTNAME,
-    MONGO_USERNAME,
     MONGO_PASSWORD,
+    MONGO_USERNAME,
+    MONGODB_CONNECTION,
+    MONGODB_HOSTNAME,
 )
 
 logger = getLogger(__name__)

--- a/src/api/config/schedule.py
+++ b/src/api/config/schedule.py
@@ -40,6 +40,7 @@ from processing import (
     save_dataframe,
 )
 from utils import BatchTally, track_time
+
 from .cache import cache
 from .dump import generate_sql_dump
 from .git import append_commit_files, create_archive, update_git_files

--- a/src/modeling/train_model.py
+++ b/src/modeling/train_model.py
@@ -7,7 +7,7 @@ from os import cpu_count, environ
 from pathlib import Path
 from threading import Thread
 
-from pandas import DataFrame, read_csv, Series, to_datetime
+from pandas import DataFrame, Series, read_csv, to_datetime
 from pytz import UTC
 from sklearn.model_selection import RandomizedSearchCV
 
@@ -27,12 +27,13 @@ from processing import (
     backward_elimination,
     current_hour,
     encode_categorical_data,
-    generate_features,
     fetch_summary_dataframe,
+    generate_features,
     value_scaling,
 )
 from utils import BatchOutcome, track_time
 from visualization import draw_errors, draw_predictions
+
 from .process_results import save_errors, save_results
 
 logger = getLogger(__name__)

--- a/src/models/base_regression_model.py
+++ b/src/models/base_regression_model.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from pickle import dumps, HIGHEST_PROTOCOL, load
+from pickle import HIGHEST_PROTOCOL, dumps, load
 
 
 class BaseRegressionModel:

--- a/src/preparation/weather_data.py
+++ b/src/preparation/weather_data.py
@@ -4,7 +4,7 @@ from os import environ
 from time import sleep
 
 from pandas import DataFrame, json_normalize
-from requests import get, RequestException
+from requests import RequestException, get
 
 from definitions import (
     DATA_PATH,

--- a/src/processing/__init__.py
+++ b/src/processing/__init__.py
@@ -10,10 +10,10 @@ from .feature_selection import backward_elimination
 from .forecast_data import fetch_forecast_result
 from .handle_data import (
     drop_unnecessary_features,
+    fetch_summary_dataframe,
     find_missing_data,
     read_csv_in_chunks,
     rename_features,
-    fetch_summary_dataframe,
     save_dataframe,
     trim_dataframe,
 )

--- a/src/processing/feature_generation.py
+++ b/src/processing/feature_generation.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime
 
 from numpy import abs, cos, pi, sin
-from pandas import cut, DataFrame, Series
+from pandas import DataFrame, Series, cut
 from statsmodels.tsa.stattools import pacf
 
 DAYS_IN_MONTH = 30

--- a/src/processing/feature_selection.py
+++ b/src/processing/feature_selection.py
@@ -1,5 +1,5 @@
 from pandas import DataFrame, Series
-from statsmodels.api import add_constant, OLS
+from statsmodels.api import OLS, add_constant
 
 
 def get_p_values(x: DataFrame, y: Series, features: list) -> Series:

--- a/src/processing/forecast_data.py
+++ b/src/processing/forecast_data.py
@@ -4,13 +4,14 @@ from logging import getLogger
 from math import isnan, nan
 from typing import Optional
 
-from pandas import concat, DataFrame, date_range, Series
+from pandas import DataFrame, Series, concat, date_range
 
 from api.config.cache import cache
 from definitions import CACHE_TIMEOUTS, DATA_PROCESSED_PATH, MODELS_PATH, POLLUTANTS
 from models import make_model
 from models.base_regression_model import BaseRegressionModel
 from preparation import location_timezone
+
 from .feature_generation import encode_categorical_data, generate_features
 from .feature_scaling import value_scaling
 from .handle_data import fetch_summary_dataframe, read_csv_in_chunks

--- a/src/processing/handle_data.py
+++ b/src/processing/handle_data.py
@@ -3,7 +3,7 @@ from logging import getLogger
 from pathlib import Path
 from typing import Optional
 
-from pandas import concat, DataFrame, read_csv, to_datetime
+from pandas import DataFrame, concat, read_csv, to_datetime
 
 from api.config.repository import RepositorySingleton
 from definitions import CHUNK_SIZE, COLLECTIONS

--- a/src/processing/normalize_data.py
+++ b/src/processing/normalize_data.py
@@ -1,12 +1,13 @@
 from datetime import datetime, timedelta, tzinfo
 from logging import getLogger
 
-from pandas import concat, Series, to_numeric
+from pandas import Series, concat, to_numeric
 from pytz import timezone
 from sklearn.impute import KNNImputer
 
 from definitions import DATA_PROCESSED_PATH, DATA_RAW_PATH, POLLUTANTS
 from utils import BatchOutcome
+
 from .calculate_index import calculate_aqi, calculate_index
 from .handle_data import (
     drop_unnecessary_features,

--- a/src/visualization/algorithm_errors.py
+++ b/src/visualization/algorithm_errors.py
@@ -3,6 +3,7 @@ from matplotlib import pyplot
 from pandas import DataFrame, read_csv
 
 from definitions import POLLUTANTS, REGRESSION_MODELS, RESULTS_ERRORS_PATH
+
 from .handle_plot import save_plot
 
 ERROR_TYPES = {

--- a/src/visualization/algorithm_predictions.py
+++ b/src/visualization/algorithm_predictions.py
@@ -7,6 +7,7 @@ from definitions import (
     RESULTS_ERRORS_PATH,
     RESULTS_PREDICTIONS_PATH,
 )
+
 from .handle_plot import save_plot
 
 PLOT_PARAMS = {

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -12,13 +12,13 @@ and pin the one thing that genuinely did change: an unexpected error now propaga
 instead of being answered with a 404.
 """
 
+from http import HTTPStatus
 from json import dumps
 from pathlib import Path
 
 import pytest
 from flask import Flask
 from pandas import DataFrame
-from starlette.status import HTTP_404_NOT_FOUND
 
 # Import the config package first so the api/preparation/processing chain initialises in
 # order — importing an ``api`` submodule first hits a circular import.
@@ -63,7 +63,7 @@ def test_answers_404_when_the_csv_is_missing(app_context, processed):
 
     assert isinstance(result, tuple)
     _, status = result
-    assert status == HTTP_404_NOT_FOUND
+    assert status == HTTPStatus.NOT_FOUND
 
 
 def test_answers_404_when_the_csv_parses_but_holds_no_rows(app_context, processed):
@@ -75,7 +75,7 @@ def test_answers_404_when_the_csv_parses_but_holds_no_rows(app_context, processe
     result = fetch_dataframe(Path("skopje") / "1000", "pollution")
 
     assert isinstance(result, tuple)
-    assert result[1] == HTTP_404_NOT_FOUND
+    assert result[1] == HTTPStatus.NOT_FOUND
 
 
 def test_an_unexpected_error_propagates_rather_than_becoming_a_404(

--- a/tests/test_forecast_data.py
+++ b/tests/test_forecast_data.py
@@ -12,7 +12,7 @@ from json import dumps
 import numpy as np
 import pytest
 from flask import Flask
-from pandas import date_range, DataFrame
+from pandas import DataFrame, date_range
 
 # Import the config package first so the api/preparation/processing chain initialises
 # in order — importing a ``processing`` submodule first hits a circular import.

--- a/tests/test_normalize_data.py
+++ b/tests/test_normalize_data.py
@@ -13,13 +13,13 @@ import pytest
 # Import the config package first so the api/preparation/processing chain initialises
 # in order — importing a ``processing`` submodule first hits a circular import.
 import api.config  # noqa: F401
-from utils import BatchOutcome
 from processing.normalize_data import (
     closest_hour,
     current_hour,
     flatten_json,
     next_hour,
 )
+from utils import BatchOutcome
 
 
 @pytest.mark.parametrize(

--- a/tests/test_train_integration.py
+++ b/tests/test_train_integration.py
@@ -21,8 +21,8 @@ from pandas import DataFrame, date_range
 # Import the config package first so the api/preparation/processing chain initialises
 # in order — importing a package submodule first can hit a circular import.
 import api.config  # noqa: F401
-from models import make_model
 from modeling import process_results, train_model
+from models import make_model
 from processing.normalize_data import current_hour
 
 _MODELS = {


### PR DESCRIPTION
Reconciles this repo's backlog and implements what survived.

**178 tests**, black, ruff and the full suite green, plus CI on this PR.

### Four entries were already shipped

The guarded `kubectl get` reads, the retry gate, the 248s `chown` (#60) and the pip cache key (#61, now `requirements/*.txt`). Deleted rather than struck.

### `starlette` dropped

It was a **production dependency** carried for three integer constants — 400, 404, 500 — that `http.HTTPStatus` already provides. Eleven modules rewritten; the dependency and its orphaned transitive `anyio` removed from `common.txt` and both locks.

**The locks were edited surgically rather than recompiled.** A trial recompile proved only those two entries change — and it also overwrote the hand-written header and resolved under Python 3.13 while the project targets 3.14, so editing the original keeps the provenance honest.

**Verified by uninstalling `starlette` and `anyio` from the environment and re-running the suite.** That is what caught `tests/test_blueprints.py`, which still imported it and which a source-only sweep had missed. 178 passed with the package absent.

### Ruff now gates import order

`select` had `F401` and `F811` but not `I`: unused imports were gated and their *order* was not, so a hand-added import in the wrong block passed CI and surfaced later as diff noise in someone else's commit. 30 findings, all auto-fixed.

### Still open, and deliberately yours

The DarkSky **code** is gone, but `DARK_SKY_TOKEN` survives in `kubernetes/sealed-secret/flask-sealed-secret.yml`. Removing it means re-sealing the secret — a deployment step, so it stays owner-side.

https://claude.ai/code/session_01PGKAf76eTKBQYKiecbUff1
